### PR TITLE
现代作品：收录《第二次汉字简化方案（草案）》（1977）

### DIFF
--- a/.sources/honoka55/erjian-cao/2026-07-10/index.html
+++ b/.sources/honoka55/erjian-cao/2026-07-10/index.html
@@ -1,0 +1,2395 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="zh-cn">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1" name="viewport"/>
+<meta content="第二次汉字简化方案
+（草案）
+电子化｜焰华Honoka55 " name="description"/>
+<title>第二次汉字简化方案（草案） | 焰色升空，华樱落尘</title>
+<link href="https://honoka55.github.io/p/erjian-cao/" rel="canonical"/>
+<link href="/scss/style.min.css" rel="stylesheet"/>
+<meta content="第二次汉字简化方案（草案）" property="og:title"/>
+<meta content="第二次汉字简化方案
+（草案）
+电子化｜焰华Honoka55 " property="og:description"/>
+<meta content="https://honoka55.github.io/p/erjian-cao/" property="og:url"/>
+<meta content="焰色升空，华樱落尘" property="og:site_name"/>
+<meta content="article" property="og:type"/>
+<meta content="Post" property="article:section"/>
+<meta content="电子化" property="article:tag"/>
+<meta content="1977-05-01T00:00:00+00:00" property="article:published_time"/>
+<meta content="1977-05-01T00:00:00+00:00" property="article:modified_time"/>
+<meta content="https://honoka55.github.io/p/erjian-cao/erjian-1.png" property="og:image"/>
+<meta content="第二次汉字简化方案（草案）" name="twitter:title"/>
+<meta content="第二次汉字简化方案
+（草案）
+电子化｜焰华Honoka55 " name="twitter:description"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="https://honoka55.github.io/p/erjian-cao/erjian-1.png" name="twitter:image"/>
+</head>
+<body class="article-page">
+<script>!function(){const e="StackColorScheme";localStorage.getItem(e)||localStorage.setItem(e,"auto")}();</script><script>!function(){const e=localStorage.getItem("StackColorScheme"),t=!0===window.matchMedia("(prefers-color-scheme: dark)").matches;document.documentElement.dataset.scheme="dark"==e||"auto"===e&&t?"dark":"light"}();</script>
+<div class="container main-container flex on-phone--column extended">
+<aside class="sidebar left-sidebar sticky">
+<button aria-label="切换菜单" class="hamburger hamburger--spin" id="toggle-menu" type="button">
+<span class="hamburger-box"><span class="hamburger-inner"></span></span>
+</button>
+<header>
+<figure class="site-avatar">
+<a href="/"><img alt="Avatar" class="site-logo" height="300" loading="lazy" src="/img/avatar_hu7d9b67be7ef950d905465e1960632c76_41038_300x0_resize_box_3.png" width="300"/></a>
+<span class="emoji">😴</span>
+</figure>
+<div class="site-meta">
+<h1 class="site-name"><a href="/">焰华Honoka55</a></h1>
+<h2 class="site-description">焰色升空，华樱落尘</h2>
+</div>
+</header>
+<ol class="social-menu">
+<li><a href="https://afdian.com/a/honoka55" target="_blank" title="AFDIAN"><svg class="icon icon-tabler icon-tabler-social-afdian" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><g id="layer1" transform="translate(0,-263.13332)"><path class="st0" d="M5.6,268c0.5,0,0.8,0.1,1.1,0.3c0.2,0.2,0.2,0.3,0.2,0.5c0,0.1,0,0.2-0.1,0.3c0,0.1-0.1,0.2-0.2,0.2c-0.1,0.1-0.2,0.2-0.4,0.3c-0.2,0.1-0.4,0.2-0.6,0.3l-0.4,0.2l0,0c-1.1-0.2-1.4-0.2-1.4-0.2c0,0,0.7,0.1,1.6,0.2c0.7,0,1.2,0,1.4,0c0,0,0.9,0,3.4-0.1c3.2-0.1,4.8,0.1,6.5,1c2,1,3.8,3,4.1,4.5c0.2,0.8,0.1,1.8-0.2,2.8c0,0.1-0.1,0.2-0.1,0.3c0,0,0,0,0,0c-0.8-0.1-1.1-0.2-1.1-0.2c0,0,1.1,0,2,0.6c0.2,0.2,0.4,0.3,0.5,0.6c0.2,0.6-0.2,1.3-0.8,1.6c-0.7,0.4-1.8,0.1-2.5-0.7c0.2,0.2,0.5,0.4,0.7,0.5l-0.4,0.4c-0.6,0.5-1,0.8-1.8,1.2c-1,0.5-2.2,0.8-3.5,0.9c-2.7,0.3-5.8-0.5-7.3-1.9c-0.4-0.4-0.9-1-1-1.5c-0.3-0.8-0.2-1.8,0.1-2.4c0.1-0.2,0.2-0.3,0.2-0.3c0,0,0,0,0.2-0.2l0,0c-0.2-0.1-0.6-0.5-0.8-1.1c-0.1-0.2-0.3-0.8,0-1.1c0.3-0.4,1.1-0.2,1.5-0.1c0.7,0.1,1.2,0.4,1.5,0.6c-0.7,0.6-1.4,1.1-2.2,1.7c1.2-1,2.5-1.9,3.7-2.9c1.5-1,2.3-1.5,2.3-1.5c0,0-0.7,0.4-2.1,1.3c0,0-0.1,0-0.1,0c-0.2,0-0.5-0.1-1-0.1c-1.5-0.2-3.6-0.6-4.5-0.9c-0.9-0.3-2-0.9-2.4-1.4c-0.4-0.4-0.5-0.7-0.5-1.2c0-0.5,0.2-0.8,0.6-1.3c0.6-0.5,1.8-1.1,3.6-1.2C5.5,268.1,5.6,268.1,5.6,268z M8.9,277.7c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.2,0.2,0.2,0.3c0,0.1-0.1,0.2-0.2,0.3c-0.1,0.1-0.2,0.2-0.3,0.2c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.2-0.2-0.2-0.3s0.1-0.2,0.2-0.3C8.7,277.8,8.8,277.7,8.9,277.7z M13.5,279c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.2,0.2,0.2,0.3s-0.1,0.2-0.2,0.3c-0.1,0.1-0.2,0.2-0.3,0.2c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.2-0.2-0.2-0.3c0-0.1,0.1-0.2,0.2-0.3C13.3,279.1,13.4,279,13.5,279z" id="path845"></path></g></svg></a></li>
+<li><a href="https://space.bilibili.com/7398042" target="_blank" title="bilibili"><svg class="icon icon-tabler icon-tabler-social-bilibili" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><style>.st0{fill:none}</style><path class="st0" d="M17.4,18.9H6.7c-1.5,0-2.8-1.2-2.8-2.8V9.9c0-1.5,1.2-2.8,2.8-2.8h10.7c1.5,0,2.8,1.2,2.8,2.8v6.2C20.1,17.6,18.9,18.9,17.4,18.9z"></path><line class="st1" x1="7.4" x2="10.5" y1="4.1" y2="7.2"></line><line class="st1" x1="16.5" x2="13.4" y1="4.1" y2="7.2"></line><line class="st1" x1="9" x2="9" y1="12.1" y2="12.9"></line><line class="st1" x1="15.1" x2="15.1" y1="12.1" y2="12.9"></line></svg></a></li>
+<li><a href="https://github.com/honoka55" target="_blank" title="GitHub"><svg class="icon icon-tabler icon-tabler-social-github" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none" stroke="none"></path><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5"></path></svg></a></li>
+<li><a href="http://zhs.glyphwiki.org/wiki/User:honoka55" target="_blank" title="GlyphWiki"><svg class="icon icon-tabler icon-tabler-social-glyphwiki" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><g><path d="M11.9,20.5l2-0.5l0.1,0l0.1,0l0.1-0.1l0,0l0-0.1l0-0.1l0-0.1l-1.5-4.7l-8.3,1.8l-0.1-0.4l8.3-1.8l-0.8-2.6l1.3-0.1l0.3-0.6l0.3-0.5l0.3-0.5l0.3-0.4l0.2-0.4L14.6,9l0.1-0.1L7,10.5l-0.1-0.4L15,8.3l0,0L15.1,8l0.1,0l0.3-0.4l1.4,0.7l-0.4,0.4l-0.6,0.5l-0.1,0.1l-0.3,0.3L15.2,10l-0.3,0.4l-0.4,0.4l-0.4,0.4l-0.4,0.4l-0.4,0.4L13.2,12l-0.1,0.1l0.6,2.1l6.1-1.4l0.7-1.2l1.5,0.7l0.1,0.4l-8.4,1.9l1.5,4.7l0.1,0.3l0,0.3l0,0.3l-0.1,0.3l-0.1,0.2l-0.2,0.2L15,20.9l-0.2,0.1l-0.2,0.1l-0.2,0.1l-0.2-0.6L12,20.8L11.9,20.5z M4,8.6l0.2,0.6l0.1,0.6l0,0.5l0,0.5l-0.1,0.5L4,11.6L3.8,12l-0.4,0.2l-0.5-0.1l-0.2-0.4l0.1-0.4L2.9,11l0.1-0.2l0.1-0.3l0.1-0.4l0.1-0.4l0-0.5l0-0.5L3.3,8L3.2,7.4L3,6.6l0.2-0.1l0.3,0.7l0.2,0.5L10,6.4l-1-3l1.3-0.1l0.4,0.1l-0.2,0.3l0.8,2.5l6.6-1.5l0-0.1l0,0l0,0L18.3,4l1.4,0.7l-0.4,0.4l-0.3,0.2L19,5.4l-0.1,0.3l-0.1,0.3l-0.1,0.4l-0.2,0.4l-0.2,0.4l-0.2,0.4L17.9,8l-0.2,0.4l-0.2-0.1l0.1-0.5l0.1-0.5L17.7,7l0.1-0.4l0-0.4l0-0.4l0-0.3l0-0.3l0-0.1l-14,3.1L4,8.6z"></path></g></svg></a></li>
+</ol>
+<ol class="menu" id="main-menu">
+<li><a href="/"><svg class="icon icon-tabler icon-tabler-home" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><polyline points="5 12 3 12 12 3 21 12 19 12"></polyline><path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7"></path><path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6"></path></svg><span>主页</span></a></li>
+<li><a href="/search/"><svg class="icon icon-tabler icon-tabler-search" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><circle cx="10" cy="10" r="7"></circle><line x1="21" x2="15" y1="21" y2="15"></line></svg><span>搜索</span></a></li>
+<li><a href="/tools/"><svg class="icon icon-tabler icon-tabler-tool" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none" stroke="none"></path><path d="M7 10h3v-3l-3.5 -3.5a6 6 0 0 1 8 8l6 6a2 2 0 0 1 -3 3l-6 -6a6 6 0 0 1 -8 -8l3.5 3.5"></path></svg><span>工具</span></a></li>
+<li><a href="/about/"><svg class="icon icon-tabler icon-tabler-user" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><circle cx="12" cy="7" r="4"></circle><path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2"></path></svg><span>关于</span></a></li>
+<li><a href="/links/"><svg class="icon icon-tabler icon-tabler-link" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5"></path></svg><span>友链</span></a></li>
+<div class="menu-bottom-section">
+<li id="i18n-switch"><svg class="icon icon-tabler icon-tabler-language" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none" stroke="none"></path><path d="M4 5h7"></path><path d="M9 3v2c0 4.418 -2.239 8 -5 8"></path><path d="M5 9c-.003 2.144 2.952 3.908 6.7 4"></path><path d="M12 20l4 -9l4 9"></path><path d="M19.1 18h-6.2"></path></svg>
+<select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+<option value="https://honoka55.github.io/ja/">日本語</option>
+<option selected="" value="https://honoka55.github.io/">中文</option>
+</select>
+</li>
+<li id="dark-mode-toggle"><svg class="icon icon-tabler icon-tabler-toggle-left" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><circle cx="8" cy="12" r="2"></circle><rect height="12" rx="6" width="20" x="2" y="6"></rect></svg><svg class="icon icon-tabler icon-tabler-toggle-right" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><circle cx="16" cy="12" r="2"></circle><rect height="12" rx="6" width="20" x="2" y="6"></rect></svg><span>深色模式</span></li>
+</div>
+</ol>
+</aside>
+<main class="main full-width">
+<article class="has-image main-article">
+<header class="article-header">
+<div class="article-image">
+<a href="/p/erjian-cao/"><img alt="Featured image of post 第二次汉字简化方案（草案）" height="296" loading="lazy" src="/p/erjian-cao/erjian-1_hu23f51d9cce8b61a70767939631ee54c9_65646_800x0_resize_box_3.png" srcset="/p/erjian-cao/erjian-1_hu23f51d9cce8b61a70767939631ee54c9_65646_800x0_resize_box_3.png 800w, /p/erjian-cao/erjian-1_hu23f51d9cce8b61a70767939631ee54c9_65646_1600x0_resize_box_3.png 1600w" width="800"/></a>
+</div>
+<div class="article-details">
+<header class="article-category">
+<a href="/categories/%E6%B1%89%E5%AD%97/">汉字</a>
+</header>
+<div class="article-title-wrapper">
+<h2 class="article-title"><a href="/p/erjian-cao/">第二次汉字简化方案（草案）</a></h2>
+</div>
+<footer class="article-time">
+<div>
+<svg class="icon icon-tabler icon-tabler-calendar-time" fill="none" height="56" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="56" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" stroke="none"></path><path d="M11.795 21h-6.795a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v4"></path><circle cx="18" cy="18" r="4"></circle><path d="M15 3v4"></path><path d="M7 3v4"></path><path d="M3 11h16"></path><path d="M18 16.496v1.504l1 1"></path></svg>
+<time class="article-time--published">1977年5月1号</time>
+</div>
+</footer>
+</div>
+</header>
+<section class="article-content">
+<center><big><big><strong>第二次汉字简化方案</strong><br/></big>（草案）</big><br/>电子化｜焰华Honoka55
+<hr/></center>
+<center><h2 style="font-family:FangSong,serif">说明</h2></center>
+<p style="text-indent:2em">一、草案为什么分两个表？</p>
+<p style="font-family:SimSun,serif;text-indent:2em">这是因为两个表所收简化字的流行情况不同。</p>
+<p style="font-family:SimSun,serif;text-indent:2em">第一表所收的简化字已在全国流行，可在出版物上先行试用。</p>
+<p style="font-family:SimSun,serif;text-indent:2em">第二表所收的简化字有三种情况：（一）已在部分地区或某个行业中流行。这类字占大多数。（二）有些字是从社会上流行的几种不同简体中选用的，选用得是否合适，还需要讨论。这类字占一小部分。（三）还有少数字，原字笔画较繁而又比较常用，是我们根据群众简化汉字的方法拟订的。因此，第二表的简化字，需要经过群众广泛讨论，提出修改、增补或者删除的意见。</p>
+<p style="text-indent:2em">二、草案一共收了多少简化字？</p>
+<p style="font-family:SimSun,serif;text-indent:2em">第一表收简化字193个（其中不作简化偏旁的简化字172个，可作简化偏旁的简化字21个）；类推出来的简化字55个。以上两项合计，共248个。</p>
+<p style="font-family:SimSun,serif;text-indent:2em">第二表收简化字269个（其中不作简化偏旁的简化字245个，可作简化偏旁的简化字24个）；此外，不能单独成字的简化偏旁16个。根据24个可作简化偏旁的简化字和16个不能单独成字的简化偏旁，类推出来的简化字336个。以上两项合计，共605个。</p>
+<p style="font-family:SimSun,serif;text-indent:2em">整个草案，共收简化字853个，简化偏旁61个。</p>
+<p style="font-family:SimSun,serif;text-indent:2em">在精简汉字数量方面，草案精简了263个字。</p>
+<p style="text-indent:2em">三、草案中的类推字是在什么范围內类推简化的？</p>
+<p style="font-family:SimSun,serif;text-indent:2em">按说，一个偏旁简化了，所有包含这个偏旁的字都应该同样简化。但是，考虑到汉字总数很多，其中有很大一部分是死字、古字，现代汉语中已经不用，没有必要把所有可以类推的字全部类推简化。因此，草案中的类推简化字，暂在4500个较常用字范围内类推简化。</p>
+<p style="text-indent:2em">四、还有哪些字急需简化？</p>
+<p style="font-family:SimSun,serif;text-indent:2em">这次简化以后，在4500个较常用字中，超过十笔的还有1300字。其中使用频率较高而急需简化的字举例如下：</p>
+<p style="font-family:SimSun,serif;margin-left:2em">衡　醒　酷　增　横　题　篇　端　缩　豪　群　溪　御　融　蹄　赠　薪　操　额　醋　嫩　嗽　辣　撇　誓　舅　嗅　赖　罩　缴　慧　隔　谨　捷　滞　骡　纂　攥　撑　鳞　蹦　髓</p>
+<p style="font-family:SimSun,serif;text-indent:2em">此外，还有一些笔画不算多，但是难写难读或容易写错读错的字，也需要在简化过程中求得解决。</p>
+<p style="font-family:SimSun,serif;text-indent:2em">这些字怎样简化，希望大家研究讨论。</p>
+<p style="text-align:right;margin-right:4em">中国文字改革委员会</p>
+<p style="font-family:SimSun,serif;text-align:right;margin-right:2em">1977年5月</p>
+<center><h2>第一表</h2></center>
+<center><h3>（1）不作简化偏旁的简化字<br/>（<span style="font-family:SimSun,serif">172个</span>）</h3></center>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">懊</td>
+<td style="font-family:SimSun,serif">㤇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">芭笆粑</td>
+<td style="font-family:SimSun,serif">巴</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">帮</td>
+<td style="font-family:SimSun,serif">邦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">爆</td>
+<td style="font-family:erjian,SimSun,serif">𤆊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蓖篦蔽</td>
+<td style="font-family:SimSun,serif">芘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">弊</td>
+<td style="font-family:erjian,SimSun,serif">𰐉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">壁</td>
+<td style="font-family:SimSun,serif">坒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">萹藊稨</td>
+<td style="font-family:SimSun,serif">扁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">摒</td>
+<td style="font-family:SimSun,serif">屏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">病</td>
+<td style="font-family:SimSun,serif">疒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">播</td>
+<td style="font-family:SimSun,serif">抪</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">部</td>
+<td style="font-family:erjian,SimSun,serif">𰆊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">彩</td>
+<td style="font-family:SimSun,serif">采</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">菜蔡</td>
+<td style="font-family:erjian,SimSun,serif">𦬁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">餐</td>
+<td style="font-family:SimSun,serif">歺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舱</td>
+<td style="font-family:SimSun,serif">仓</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">藏</td>
+<td style="font-family:SimSun,serif">䒙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">衩扠杈汊</td>
+<td style="font-family:SimSun,serif">叉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">撤</td>
+<td style="font-family:erjian,SimSun,serif">𢪃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瞅</td>
+<td style="font-family:erjian,SimSun,serif">𥄨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">矗</td>
+<td style="font-family:erjian,SimSun,serif">𰅹</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">葱</td>
+<td style="font-family:SimSun,serif">茐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">答</td>
+<td style="font-family:SimSun,serif">荅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蛋</td>
+<td style="font-family:SimSun,serif">旦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">弹</td>
+<td style="font-family:erjian,SimSun,serif">𰐔</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蹈</td>
+<td style="font-family:erjian,SimSun,serif">𰸁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">稻</td>
+<td style="font-family:erjian,SimSun,serif">𰨛</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">道</td>
+<td style="font-family:SimSun,serif">辺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">殿</td>
+<td style="font-family:erjian,SimSun,serif">𡱒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">叮盯钉靪</td>
+<td style="font-family:SimSun,serif">丁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">董</td>
+<td style="font-family:SimSun,serif">苳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">懂</td>
+<td style="font-family:SimSun,serif">㤏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">短</td>
+<td style="font-family:erjian,SimSun,serif">𰦓</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蹲</td>
+<td style="font-family:erjian,SimSun,serif">𧿬</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">燉</td>
+<td style="font-family:SimSun,serif">炖</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">贰</td>
+<td style="font-family:SimSun,serif">弍</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">愤</td>
+<td style="font-family:SimSun,serif">忿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">孵</td>
+<td style="font-family:SimSun,serif">孚</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">伕</td>
+<td style="font-family:SimSun,serif">夫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">富</td>
+<td style="font-family:erjian,SimSun,serif">𫲷</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">副</td>
+<td style="font-family:SimSun,serif">付</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">秆竿</td>
+<td style="font-family:SimSun,serif">杆</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">钩</td>
+<td style="font-family:SimSun,serif">勾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">罐</td>
+<td style="font-family:erjian,SimSun,serif">𰭃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">灌盥</td>
+<td style="font-family:erjian,SimSun,serif">浂</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鳜</td>
+<td style="font-family:SimSun,serif">桂</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">裹</td>
+<td style="font-family:SimSun,serif">果</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">薅</td>
+<td style="font-family:SimSun,serif">䒵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">盒</td>
+<td style="font-family:SimSun,serif">合</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">葫猢蝴糊</td>
+<td style="font-family:SimSun,serif">胡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">毁</td>
+<td style="font-family:erjian,SimSun,serif">毁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">籍</td>
+<td style="font-family:SimSun,serif">笈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">建</td>
+<td style="font-family:SimSun,serif">迠</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">豇</td>
+<td style="font-family:SimSun,serif">江</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">酱</td>
+<td style="font-family:erjian,SimSun,serif">𪧷</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">跤</td>
+<td style="font-family:SimSun,serif">交</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">椒</td>
+<td style="font-family:SimSun,serif">茭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">街</td>
+<td style="font-family:SimSun,serif">亍</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">阱</td>
+<td style="font-family:SimSun,serif">井</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">境</td>
+<td style="font-family:SimSun,serif">㘫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镜</td>
+<td style="font-family:erjian,SimSun,serif">𰽟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">韭</td>
+<td style="font-family:SimSun,serif">艽<sup id="ref-1"><a class="themed-link" href="#note-1">①</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">酒</td>
+<td style="font-family:SimSun,serif">氿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">橘</td>
+<td style="font-family:SimSun,serif">桔<sup id="ref-2"><a class="themed-link" href="#note-2">②</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镢䦆</td>
+<td style="font-family:erjian,SimSun,serif">𰽤</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">慷</td>
+<td style="font-family:SimSun,serif">忼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">糠</td>
+<td style="font-family:SimSun,serif">粇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">靠</td>
+<td style="font-family:SimSun,serif">俈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">款</td>
+<td style="font-family:erjian,SimSun,serif">𤘯</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蓝篮</td>
+<td style="font-family:SimSun,serif">兰</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">澜滥</td>
+<td style="font-family:SimSun,serif">㳕</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">谰</td>
+<td style="font-family:erjian,SimSun,serif">𰵟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">懒</td>
+<td style="font-family:erjian,SimSun,serif">𰑐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">缆</td>
+<td style="font-family:erjian,SimSun,serif">𰬊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">磊</td>
+<td style="font-family:erjian,SimSun,serif">𰦫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">荔</td>
+<td style="font-family:SimSun,serif">艻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">璃</td>
+<td style="font-family:SimSun,serif">玏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">量</td>
+<td style="font-family:erjian,SimSun,serif">𰅊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">潦</td>
+<td style="font-family:SimSun,serif">了<sup id="ref-3"><a class="themed-link" href="#note-3">③</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">僚</td>
+<td style="font-family:erjian,SimSun,serif">𠆨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">燎</td>
+<td style="font-family:erjian,SimSun,serif">𰝶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">寮寥</td>
+<td style="font-family:SimSun,serif">㝋</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">廖</td>
+<td style="font-family:erjian,SimSun,serif">𭙏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">磷</td>
+<td style="font-family:SimSun,serif">砱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">龄</td>
+<td style="font-family:SimSun,serif">令</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">溜遛熘馏</td>
+<td style="font-family:erjian,SimSun,serif">𰜈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">掳</td>
+<td style="font-family:SimSun,serif">虏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">慢</td>
+<td style="font-family:erjian,SimSun,serif">𭜌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">帽</td>
+<td style="font-family:erjian,SimSun,serif">𫷀</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">貌</td>
+<td style="font-family:SimSun,serif">皃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">煤</td>
+<td style="font-family:erjian,SimSun,serif">𭳿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">幕</td>
+<td style="font-family:erjian,SimSun,serif">𫯜</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">酿</td>
+<td style="font-family:erjian,SimSun,serif">𰼃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">虐</td>
+<td style="font-family:erjian,SimSun,serif">𰀂</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">漆</td>
+<td style="font-family:SimSun,serif">㲺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">歧</td>
+<td style="font-family:SimSun,serif">岐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">器</td>
+<td style="font-family:erjian,SimSun,serif">𫩏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">谦</td>
+<td style="font-family:erjian,SimSun,serif">𰵋</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">潜</td>
+<td style="font-family:SimSun,serif">汘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">歉</td>
+<td style="font-family:SimSun,serif">欠</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">墙</td>
+<td style="font-family:SimSun,serif">垟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">勤</td>
+<td style="font-family:erjian,SimSun,serif">𰅉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">渠</td>
+<td style="font-family:SimSun,serif">洰</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嚷</td>
+<td style="font-family:erjian,SimSun,serif">𠮵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">壤</td>
+<td style="font-family:SimSun,serif">圵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">儒</td>
+<td style="font-family:erjian,SimSun,serif">𰁡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">赛</td>
+<td style="font-family:erjian,SimSun,serif">𡧳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">煽搧</td>
+<td style="font-family:SimSun,serif">扇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">绱鞝</td>
+<td style="font-family:SimSun,serif">上</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">杓</td>
+<td style="font-family:SimSun,serif">勺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">输</td>
+<td style="font-family:erjian,SimSun,serif">𰹰</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">爽</td>
+<td style="font-family:erjian,SimSun,serif">𰋜</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">私</td>
+<td style="font-family:SimSun,serif">厶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">算</td>
+<td style="font-family:SimSun,serif">祘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">泰</td>
+<td style="font-family:SimSun,serif">太</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">檀</td>
+<td style="font-family:SimSun,serif">枟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">糖</td>
+<td style="font-family:erjian,SimSun,serif">𰪩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">套</td>
+<td style="font-family:erjian,SimSun,serif">𰋛</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">腾</td>
+<td style="font-family:erjian,SimSun,serif">𱅑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">停</td>
+<td style="font-family:SimSun,serif">仃<sup id="ref-4"><a class="themed-link" href="#note-4">④</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">稳</td>
+<td style="font-family:erjian,SimSun,serif">𮂹</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舞</td>
+<td style="font-family:SimSun,serif">午</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">稀</td>
+<td style="font-family:SimSun,serif">希</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">熄</td>
+<td style="font-family:SimSun,serif">息</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瞎</td>
+<td style="font-family:erjian,SimSun,serif">𰥌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镶</td>
+<td style="font-family:erjian,SimSun,serif">𰽙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">橡</td>
+<td style="font-family:erjian,SimSun,serif">𬂭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">萧</td>
+<td style="font-family:SimSun,serif">肖</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鞋</td>
+<td style="font-family:erjian,SimSun,serif">𰆻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">信</td>
+<td style="font-family:SimSun,serif">伩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">雄</td>
+<td style="font-family:SimSun,serif">厷</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">修</td>
+<td style="font-family:SimSun,serif">㣊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">宣</td>
+<td style="font-family:SimSun,serif">㝉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">癣</td>
+<td style="font-family:SimSun,serif">㾌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">靴</td>
+<td style="font-family:erjian,SimSun,serif">𰆳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">雪</td>
+<td style="font-family:SimSun,serif">彐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">阎</td>
+<td style="font-family:SimSun,serif">闫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">演</td>
+<td style="font-family:erjian,SimSun,serif">𰛑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">耀曜</td>
+<td style="font-family:erjian,SimSun,serif">𭀦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">意</td>
+<td style="font-family:erjian,SimSun,serif">𰐺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">臆</td>
+<td style="font-family:erjian,SimSun,serif">肊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">翼</td>
+<td style="font-family:erjian,SimSun,serif">𰭝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">迎</td>
+<td style="font-family:SimSun,serif">迊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">影</td>
+<td style="font-family:erjian,SimSun,serif">𢒈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">臃</td>
+<td style="font-family:erjian,SimSun,serif">𦙸</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">游</td>
+<td style="font-family:SimSun,serif">沋</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">愉</td>
+<td style="font-family:erjian,SimSun,serif">𢖳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">遇</td>
+<td style="font-family:SimSun,serif">迂<sup id="ref-5"><a class="themed-link" href="#note-5">⑤</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">预豫</td>
+<td style="font-family:SimSun,serif">予</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">圆</td>
+<td style="font-family:SimSun,serif">元</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">原</td>
+<td style="font-family:erjian,SimSun,serif">𰆖</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">源</td>
+<td style="font-family:SimSun,serif">沅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">缘</td>
+<td style="font-family:erjian,SimSun,serif">𰫾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">赞</td>
+<td style="font-family:erjian,SimSun,serif">𰷣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">寨</td>
+<td style="font-family:erjian,SimSun,serif">𰌻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">账</td>
+<td style="font-family:SimSun,serif">帐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">辙</td>
+<td style="font-family:erjian,SimSun,serif">𰹹</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">整</td>
+<td style="font-family:erjian,SimSun,serif">𰋞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">籽</td>
+<td style="font-family:SimSun,serif">子</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嘴</td>
+<td style="font-family:SimSun,serif">咀<sup id="ref-6"><a class="themed-link" href="#note-6">⑥</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">座</td>
+<td style="font-family:SimSun,serif">坐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif"> </td>
+<td style="font-family:SimSun,serif"> </td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">哔叽</td>
+<td style="font-family:SimSun,serif">毕几</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">枓栱</td>
+<td style="font-family:SimSun,serif">斗拱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">咔叽</td>
+<td style="font-family:SimSun,serif">卡几</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蝌蚪</td>
+<td style="font-family:SimSun,serif">科斗</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">曚昽<br/>朦胧<br/>蒙眬</td>
+<td style="font-family:erjian,SimSun,serif">𰰡龙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">霹雳</td>
+<td style="font-family:SimSun,serif">辟历</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蚯蚓</td>
+<td style="font-family:SimSun,serif">丘引</td>
+</tr></table></div>
+</div>
+<center><h3>（2）可作简化偏旁用的简化字<br/>（<span style="font-family:SimSun,serif">21个</span>）</h3></center>
+<div style="column-width:14em;-moz-column-width:14em;-webkit-column-width:14em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+<td>类推出来的简化字</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鼻</td>
+<td style="font-family:erjian,SimSun,serif">𢍂</td>
+<td style="font-family:erjian,SimSun,serif">鼾—𰯶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">察嚓</td>
+<td style="font-family:erjian,SimSun,serif">𰌵</td>
+<td style="font-family:erjian,SimSun,serif">擦—𰓣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">感</td>
+<td style="font-family:erjian,SimSun,serif">𫹯</td>
+<td style="font-family:erjian,SimSun,serif">撼—𰓭，憾—𰑞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">冀</td>
+<td style="font-family:SimSun,serif">丠</td>
+<td style="font-family:erjian,SimSun,serif">骥—𱅌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">具</td>
+<td style="font-family:erjian,SimSun,serif">𰋙</td>
+<td style="font-family:erjian,SimSun,serif">俱—𰁬，惧—𰑌，<br/>犋—𰠱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">留</td>
+<td style="font-family:SimSun,serif">畄</td>
+<td style="font-family:erjian,SimSun,serif">榴—𰗶，瘤—𰣲</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">眉嵋</td>
+<td style="font-family:erjian,SimSun,serif">𠃜</td>
+<td style="font-family:erjian,SimSun,serif">媚—𰋻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蒙</td>
+<td style="font-family:erjian,SimSun,serif">𰰡</td>
+<td style="font-family:erjian,SimSun,serif">蠓—𰲽</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">面</td>
+<td style="font-family:erjian,SimSun,serif">𫩑</td>
+<td style="font-family:erjian,SimSun,serif">缅—𰬄</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">囊囔</td>
+<td style="font-family:erjian,SimSun,serif">𰀉</td>
+<td style="font-family:erjian,SimSun,serif">攮—𰓌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">青</td>
+<td style="font-family:erjian,SimSun,serif">𰀈</td>
+<td style="font-family:erjian,SimSun,serif">静—𰁓，靛—𰍎，<br/>请—𰵕，猜—𰡂，<br/>情—𰑊，清—𰛓，<br/>晴—𰕺，睛—𰥕，<br/>靖—𰩢，精—𰪱，<br/>菁—𰰫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">桑</td>
+<td style="font-family:erjian,SimSun,serif">𰗑</td>
+<td style="font-family:erjian,SimSun,serif">搡—𰓨，嗓—𰇢</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">属</td>
+<td style="font-family:erjian,SimSun,serif">𰍱</td>
+<td style="font-family:erjian,SimSun,serif">嘱—𰇰，瞩—𰥩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">堂</td>
+<td style="font-family:SimSun,serif">坣</td>
+<td style="font-family:erjian,SimSun,serif">螳—𰳇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">易</td>
+<td style="font-family:erjian,SimSun,serif">𠃓</td>
+<td style="font-family:erjian,SimSun,serif">剔—𰄝，惕—𰐿，<br/>赐—𰷟，锡—钖，<br/>踢—𰸄</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">婴</td>
+<td style="font-family:erjian,SimSun,serif">𰋷</td>
+<td style="font-family:erjian,SimSun,serif">缨—𰬕，樱—桜</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">展辗</td>
+<td style="font-family:erjian,SimSun,serif">𰍰</td>
+<td style="font-family:erjian,SimSun,serif">碾—𰦪</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">真</td>
+<td style="font-family:erjian,SimSun,serif">𰅴</td>
+<td style="font-family:erjian,SimSun,serif">颠—𱂪，填—𰉰，<br/>慎—𰑝，滇—𰛬，<br/>镇—𰾂</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">直</td>
+<td style="font-family:erjian,SimSun,serif">𰅰</td>
+<td style="font-family:erjian,SimSun,serif">值—𰁲，植—𰗝，<br/>殖—𰙽，置—𰭋</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">卒</td>
+<td style="font-family:SimSun,serif">卆</td>
+<td style="font-family:erjian,SimSun,serif">悴—忰，啐—𠯥，<br/>碎—砕，粹—粋，<br/>醉—酔，翠—翆，<br/>瘁—疩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">尊</td>
+<td style="font-family:erjian,SimSun,serif">𰃝</td>
+<td style="font-family:erjian,SimSun,serif">撙—𰓢</td>
+</tr>
+</table></div>
+</div>
+<center><h2>第二表</h2></center>
+<p style="font-family:SimSun,serif;text-indent:2em">第二表的简化字，按不同的简化方法分为七类。第八类是简化偏旁及可类推简化的字。 </p>
+<center><h3>1．同音代替字<small>（<span style="font-family:SimSun,serif">72个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">在现代汉语中不引起意义混淆的条件下，用笔画简单的同音字，代替笔画较繁的字。例如，以“发”代“髮”，以“范”代“範”。也就是两个或两个以上的同音字，合幷成一个字。这样，旣简化了字形，又精简了字数。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">癍</td>
+<td style="font-family:SimSun,serif">斑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鞭</td>
+<td style="font-family:SimSun,serif">卞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">辩辨辫</td>
+<td style="font-family:SimSun,serif">弁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">勃渤脖饽</td>
+<td style="font-family:SimSun,serif">孛</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">簸</td>
+<td style="font-family:SimSun,serif">波</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">澈</td>
+<td style="font-family:SimSun,serif">彻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蹙</td>
+<td style="font-family:SimSun,serif">促</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">戴</td>
+<td style="font-family:SimSun,serif">代</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">巅癫</td>
+<td style="font-family:erjian,SimSun,serif">𱂪</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">凋碉雕</td>
+<td style="font-family:SimSun,serif">刁<sup id="ref-7"><a class="themed-link" href="#note-7">⑦</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">陡</td>
+<td style="font-family:SimSun,serif">斗</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嘟</td>
+<td style="font-family:SimSun,serif">都</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">锻</td>
+<td style="font-family:SimSun,serif">煅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">墩礅蹾撉</td>
+<td style="font-family:SimSun,serif">敦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">筏阀垡</td>
+<td style="font-family:SimSun,serif">伐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">袱匐</td>
+<td style="font-family:SimSun,serif">伏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">傅</td>
+<td style="font-family:SimSun,serif">付</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">擀</td>
+<td style="font-family:SimSun,serif">赶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">赣</td>
+<td style="font-family:SimSun,serif">干</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">捍</td>
+<td style="font-family:SimSun,serif">扞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">寰</td>
+<td style="font-family:SimSun,serif">环</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">徽</td>
+<td style="font-family:SimSun,serif">辉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嫉</td>
+<td style="font-family:SimSun,serif">忌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">捡</td>
+<td style="font-family:SimSun,serif">拣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嚼</td>
+<td style="font-family:erjian,SimSun,serif">噍</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">诫</td>
+<td style="font-family:SimSun,serif">戒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">襟</td>
+<td style="font-family:erjian,SimSun,serif">𥘞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">飓</td>
+<td style="font-family:SimSun,serif">巨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">筐框眶诓哐</td>
+<td style="font-family:SimSun,serif">匡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镰</td>
+<td style="font-family:SimSun,serif">连</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镣</td>
+<td style="font-family:SimSun,serif">钌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镏</td>
+<td style="font-family:erjian,SimSun,serif">𰜈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">噜</td>
+<td style="font-family:SimSun,serif">鲁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">旅膂</td>
+<td style="font-family:SimSun,serif">吕<sup id="ref-8"><a class="themed-link" href="#note-8">⑧</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">湄楣鹛</td>
+<td style="font-family:erjian,SimSun,serif">𠃜</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蜜密</td>
+<td style="font-family:SimSun,serif">宓</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">藐</td>
+<td style="font-family:SimSun,serif">秒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">凝</td>
+<td style="font-family:SimSun,serif">泞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">襻</td>
+<td style="font-family:erjian,SimSun,serif">𥘽</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">僻</td>
+<td style="font-family:SimSun,serif">辟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">拚</td>
+<td style="font-family:SimSun,serif">拼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">柒</td>
+<td style="font-family:SimSun,serif">㲺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">签</td>
+<td style="font-family:SimSun,serif">佥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">砂</td>
+<td style="font-family:SimSun,serif">沙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">墒</td>
+<td style="font-family:SimSun,serif">垧</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蒜</td>
+<td style="font-family:SimSun,serif">祘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">镗嘡膛</td>
+<td style="font-family:SimSun,serif">坣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">霆庭</td>
+<td style="font-family:erjian,SimSun,serif">𨑳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">童</td>
+<td style="font-family:SimSun,serif">仝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">豌</td>
+<td style="font-family:SimSun,serif">宛</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">诿萎痿</td>
+<td style="font-family:SimSun,serif">委</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">慰</td>
+<td style="font-family:SimSun,serif">尉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鑫</td>
+<td style="font-family:SimSun,serif">欣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">胸</td>
+<td style="font-family:SimSun,serif">匈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">渲</td>
+<td style="font-family:SimSun,serif">㝉<sup id="ref-9"><a class="themed-link" href="#note-9">⑨</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">檐</td>
+<td style="font-family:SimSun,serif">沿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">颜</td>
+<td style="font-family:SimSun,serif">彦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">赢</td>
+<td style="font-family:erjian,SimSun,serif">盈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">榨</td>
+<td style="font-family:SimSun,serif">乍</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蘸</td>
+<td style="font-family:SimSun,serif">沾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">骤</td>
+<td style="font-family:SimSun,serif">驺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">谘</td>
+<td style="font-family:SimSun,serif">咨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鬃</td>
+<td style="font-family:SimSun,serif">骔</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">遵</td>
+<td style="font-family:erjian,SimSun,serif">𰃝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif"> </td>
+<td style="font-family:SimSun,serif"> </td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">叮咛</td>
+<td style="font-family:SimSun,serif">丁宁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">哆嗦</td>
+<td style="font-family:SimSun,serif">多索</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">吩咐</td>
+<td style="font-family:SimSun,serif">分付</td>
+</tr>
+<tr>
+<td style="font-family:erjian,SimSun,serif">疙瘩<br/>圪垯<br/>纥𫄤</td>
+<td style="font-family:SimSun,serif">咯嗒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鬎鬁</td>
+<td style="font-family:erjian,SimSun,serif">瘌痢</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">阑尾</td>
+<td style="font-family:SimSun,serif">兰尾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嘹喨</td>
+<td style="font-family:SimSun,serif">辽亮</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蹓跶</td>
+<td style="font-family:erjian,SimSun,serif">𰜈达</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">罗嗦/噜苏</td>
+<td style="font-family:SimSun,serif">罗索</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">柠檬</td>
+<td style="font-family:erjian,SimSun,serif">宁𰰡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">磅礴</td>
+<td style="font-family:erjian,SimSun,serif">㝑薄</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">彷徨/徬徨</td>
+<td style="font-family:SimSun,serif">㝑皇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蜻蜓</td>
+<td style="font-family:erjian,SimSun,serif">𰀈𨑳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舢舨</td>
+<td style="font-family:erjian,SimSun,serif">舢板</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鹦鹉</td>
+<td style="font-family:erjian,SimSun,serif">𰋷武</td>
+</tr>
+</table></div>
+</div>
+<center><h3>2．形声字<small>（<span style="font-family:SimSun,serif">115个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">汉字中绝大部分是形声字，例如“忠”字的“心”称为“形旁”，是表示字义的；“中”称为“声旁”，是表示字音的。运用“形声”结构来简化，有下列几种情况：原字的形旁、声旁笔画太繁，改用笔画较简的形体；原字声旁表音不准，改用表音较准的常用字作声旁。原字本来不是形声字而笔画较繁，改用笔画较简的新形声字。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<td style="font-family:SimSun,serif">澳</td>
+<td style="font-family:SimSun,serif">沃<sup id="ref-10"><a class="themed-link" href="#note-10">⑩</a></sup></td>
+<tr>
+<td style="font-family:SimSun,serif">霸</td>
+<td style="font-family:erjian,SimSun,serif">霸</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瓣</td>
+<td style="font-family:erjian,SimSun,serif">瓣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">曝暴</td>
+<td style="font-family:erjian,SimSun,serif">𣅃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瀑浦</td>
+<td style="font-family:erjian,SimSun,serif">𣱶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鄙</td>
+<td style="font-family:erjian,SimSun,serif">𨚍</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">避</td>
+<td style="font-family:erjian,SimSun,serif">避</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">簿</td>
+<td style="font-family:erjian,SimSun,serif">簿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">锄</td>
+<td style="font-family:erjian,SimSun,serif">𨱄</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">储贮</td>
+<td style="font-family:SimSun,serif">㑁<sup id="ref-11"><a class="themed-link" href="#note-11">⑪</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">戳</td>
+<td style="font-family:erjian,SimSun,serif">戳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">诞</td>
+<td style="font-family:erjian,SimSun,serif">诞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">捣</td>
+<td style="font-family:SimSun,serif">㧅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">雕</td>
+<td style="font-family:erjian,SimSun,serif">𩾗</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蝶</td>
+<td style="font-family:SimSun,serif">蛈<sup id="ref-12"><a class="themed-link" href="#note-12">⑫</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蠹</td>
+<td style="font-family:erjian,SimSun,serif">𫊥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">翻</td>
+<td style="font-family:erjian,SimSun,serif">翻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">繁</td>
+<td style="font-family:erjian,SimSun,serif">繁</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">逢</td>
+<td style="font-family:erjian,SimSun,serif">逢</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">缝</td>
+<td style="font-family:erjian,SimSun,serif">缝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">敷</td>
+<td style="font-family:erjian,SimSun,serif">𪯈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">敢</td>
+<td style="font-family:SimSun,serif">攼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">焊</td>
+<td style="font-family:SimSun,serif">㶥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">壑</td>
+<td style="font-family:SimSun,serif">垥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">激</td>
+<td style="font-family:SimSun,serif">㲹</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">稽嵇</td>
+<td style="font-family:erjian,SimSun,serif">𬓠</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">假</td>
+<td style="font-family:erjian,SimSun,serif">𬽥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">简</td>
+<td style="font-family:erjian,SimSun,serif">𫈉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">健</td>
+<td style="font-family:SimSun,serif">伣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">键</td>
+<td style="font-family:erjian,SimSun,serif">𰽢</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">耩</td>
+<td style="font-family:erjian,SimSun,serif">耩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">剿</td>
+<td style="font-family:erjian,SimSun,serif">𠜅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">警儆</td>
+<td style="font-family:erjian,SimSun,serif">警</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">厩</td>
+<td style="font-family:erjian,SimSun,serif">厩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">厥</td>
+<td style="font-family:erjian,SimSun,serif">厥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">裤</td>
+<td style="font-family:SimSun,serif">䃿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">篱</td>
+<td style="font-family:SimSun,serif">竻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">犁</td>
+<td style="font-family:SimSun,serif">牞</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">痢</td>
+<td style="font-family:erjian,SimSun,serif">痢</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">砾</td>
+<td style="font-family:SimSun,serif">劯</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">律</td>
+<td style="font-family:erjian,SimSun,serif">律</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">率</td>
+<td style="font-family:erjian,SimSun,serif">率</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">聊</td>
+<td style="font-family:erjian,SimSun,serif">聊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蔑篾</td>
+<td style="font-family:erjian,SimSun,serif">𰰬</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">螟</td>
+<td style="font-family:erjian,SimSun,serif">螟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蘑</td>
+<td style="font-family:erjian,SimSun,serif">蘑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">腻</td>
+<td style="font-family:SimSun,serif">胒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蔫</td>
+<td style="font-family:erjian,SimSun,serif">𦮴</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蘖孽</td>
+<td style="font-family:erjian,SimSun,serif">𰰟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">藕</td>
+<td style="font-family:erjian,SimSun,serif">𰰤<sup id="ref-13"><a class="themed-link" href="#note-13">⑬</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">遣</td>
+<td style="font-family:erjian,SimSun,serif">遣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">谴</td>
+<td style="font-family:erjian,SimSun,serif">谴</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">锹</td>
+<td style="font-family:erjian,SimSun,serif">𫓱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瞧</td>
+<td style="font-family:erjian,SimSun,serif">𥋊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瘸</td>
+<td style="font-family:SimSun,serif">疦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瓤</td>
+<td style="font-family:erjian,SimSun,serif">瓤</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">攘</td>
+<td style="font-family:erjian,SimSun,serif">攘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">孺</td>
+<td style="font-family:erjian,SimSun,serif">孺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蠕</td>
+<td style="font-family:erjian,SimSun,serif">蠕</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">辱</td>
+<td style="font-family:erjian,SimSun,serif">辱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">褥</td>
+<td style="font-family:erjian,SimSun,serif">褥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">撒</td>
+<td style="font-family:erjian,SimSun,serif">𰒼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">膻</td>
+<td style="font-family:erjian,SimSun,serif">膻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">擅</td>
+<td style="font-family:erjian,SimSun,serif">𢩳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">剩</td>
+<td style="font-family:erjian,SimSun,serif">剩</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">薯蔬</td>
+<td style="font-family:erjian,SimSun,serif">𦬸</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">霜</td>
+<td style="font-family:erjian,SimSun,serif">霜</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">肆</td>
+<td style="font-family:erjian,SimSun,serif">肆</td>
+</tr>
+<tr>
+<td style="font-family:erjian,SimSun,serif">穗𰬸</td>
+<td style="font-family:erjian,SimSun,serif">𬜨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">艇</td>
+<td style="font-family:erjian,SimSun,serif">𦨍</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">臀</td>
+<td style="font-family:erjian,SimSun,serif">臀<sup id="ref-14"><a class="themed-link" href="#note-14">⑭</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">瘟</td>
+<td style="font-family:erjian,SimSun,serif">𤵒</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">膝</td>
+<td style="font-family:erjian,SimSun,serif">膝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">隙</td>
+<td style="font-family:erjian,SimSun,serif">隙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">辖</td>
+<td style="font-family:erjian,SimSun,serif">辖</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">暇</td>
+<td style="font-family:erjian,SimSun,serif">暇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">霞</td>
+<td style="font-family:erjian,SimSun,serif">雫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">厦</td>
+<td style="font-family:erjian,SimSun,serif">厦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">掀</td>
+<td style="font-family:SimSun,serif">㧥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">𣔙锨</td>
+<td style="font-family:SimSun,serif">㭠</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">嫌</td>
+<td style="font-family:erjian,SimSun,serif">𢙝<sup id="ref-15"><a class="themed-link" href="#note-15">⑮</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">像</td>
+<td style="font-family:erjian,SimSun,serif">𰁼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">携</td>
+<td style="font-family:erjian,SimSun,serif">𰓊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">堰</td>
+<td style="font-family:erjian,SimSun,serif">𪣈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">摇</td>
+<td style="font-family:SimSun,serif">扷</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">谣</td>
+<td style="font-family:erjian,SimSun,serif">𫍚</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">遥</td>
+<td style="font-family:erjian,SimSun,serif">遥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">遗</td>
+<td style="font-family:erjian,SimSun,serif">遗</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">姨</td>
+<td style="font-family:erjian,SimSun,serif">𫰆</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">椅</td>
+<td style="font-family:erjian,SimSun,serif">𣎷</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">屹</td>
+<td style="font-family:erjian,SimSun,serif">𡴭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">癔</td>
+<td style="font-family:erjian,SimSun,serif">𤴥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">毅</td>
+<td style="font-family:erjian,SimSun,serif">毅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">疑</td>
+<td style="font-family:erjian,SimSun,serif">疑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鹰</td>
+<td style="font-family:erjian,SimSun,serif">𪈠</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">庸</td>
+<td style="font-family:erjian,SimSun,serif">庸</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">幽</td>
+<td style="font-family:erjian,SimSun,serif">幽</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舆</td>
+<td style="font-family:erjian,SimSun,serif">舆</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">愚</td>
+<td style="font-family:erjian,SimSun,serif">愚</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">隅</td>
+<td style="font-family:erjian,SimSun,serif">隅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">辕</td>
+<td style="font-family:erjian,SimSun,serif">𰹷</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">猿</td>
+<td style="font-family:erjian,SimSun,serif">𤝌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">愿</td>
+<td style="font-family:erjian,SimSun,serif">𫹵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">越</td>
+<td style="font-family:SimSun,serif">迌</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">熨</td>
+<td style="font-family:erjian,SimSun,serif">𭴈</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">遭</td>
+<td style="font-family:erjian,SimSun,serif">遭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">糟</td>
+<td style="font-family:erjian,SimSun,serif">𮇘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">澡</td>
+<td style="font-family:erjian,SimSun,serif">澡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">渣</td>
+<td style="font-family:SimSun,serif">泎</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">铡</td>
+<td style="font-family:SimSun,serif">钆<sup id="ref-16"><a class="themed-link" href="#note-16">⑯</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">绽</td>
+<td style="font-family:erjian,SimSun,serif">𥿕</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">涨胀</td>
+<td style="font-family:erjian,SimSun,serif">涱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蒸</td>
+<td style="font-family:erjian,SimSun,serif">炡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">踵</td>
+<td style="font-family:erjian,SimSun,serif">踵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">赚</td>
+<td style="font-family:erjian,SimSun,serif">赚</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">撞</td>
+<td style="font-family:erjian,SimSun,serif">𢬂</td>
+</tr>
+</table></div>
+</div>
+<center><h3>3．特征字<small>（<span style="font-family:SimSun,serif">32个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">用原字的特征部分来代替原字，这样旣减少了笔画，又容易辨认。有一部分汉字的结构，描写起来很费劲，不便称说，例如，“候”字简化为“<span style="font-family:erjian,SimSun,serif">𫶬</span>”，便于称说，易学易记。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">插锸臿</td>
+<td style="font-family:erjian,SimSun,serif">臿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">得</td>
+<td style="font-family:erjian,SimSun,serif">𬁟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">德</td>
+<td style="font-family:erjian,SimSun,serif">德</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">费</td>
+<td style="font-family:SimSun,serif">弗<sup id="ref-17"><a class="themed-link" href="#note-17">⑰</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蜂峰烽锋</td>
+<td style="font-family:SimSun,serif">夆</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鼓臌</td>
+<td style="font-family:SimSun,serif">壴</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">滚衮磙</td>
+<td style="font-family:erjian,SimSun,serif">衮</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">侯候</td>
+<td style="font-family:erjian,SimSun,serif">𫶬</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">既</td>
+<td style="font-family:SimSun,serif">旡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">疆缰</td>
+<td style="font-family:erjian,SimSun,serif">畺</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">解</td>
+<td style="font-family:erjian,SimSun,serif">𭷔</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">浸</td>
+<td style="font-family:erjian,SimSun,serif">𪫆</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">侵</td>
+<td style="font-family:erjian,SimSun,serif">侵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鞠掬</td>
+<td style="font-family:SimSun,serif">匊</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">垒儡</td>
+<td style="font-family:SimSun,serif">厽</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">漏</td>
+<td style="font-family:erjian,SimSun,serif">漏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">没</td>
+<td style="font-family:SimSun,serif">殳<sup id="ref-18"><a class="themed-link" href="#note-18">⑱</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">墓</td>
+<td style="font-family:SimSun,serif">圶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">脑瑙碯堖</td>
+<td style="font-family:SimSun,serif">㐫</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">能</td>
+<td style="font-family:erjian,SimSun,serif">𫧇</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">攀</td>
+<td style="font-family:erjian,SimSun,serif">攀</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">缺</td>
+<td style="font-family:SimSun,serif">夬</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">然</td>
+<td style="font-family:erjian,SimSun,serif">然</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">弱</td>
+<td style="font-family:erjian,SimSun,serif">弱</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">熟</td>
+<td style="font-family:erjian,SimSun,serif">𰀅</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">数</td>
+<td style="font-family:erjian,SimSun,serif">𮲓</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">酸痠</td>
+<td style="font-family:SimSun,serif">夋</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">滕藤</td>
+<td style="font-family:erjian,SimSun,serif">滕</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">微</td>
+<td style="font-family:erjian,SimSun,serif">𡵉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">涡娲窝莴</td>
+<td style="font-family:SimSun,serif">呙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">象</td>
+<td style="font-family:erjian,SimSun,serif">象</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">旋漩</td>
+<td style="font-family:erjian,SimSun,serif">𭻾</td>
+</tr>
+</table></div>
+</div>
+<center><h3>4．轮廓字<small>（<span style="font-family:SimSun,serif">23个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">保留原字的轮廓，省略其中部分笔画。用这个方法简化的字与原字形体相近。例如，“叟臾舀毁”分别简作“<span style="font-family:erjian,SimSun,serif">叟㬰舀毁</span>”，“臼”改“曰”虽只减两笔，但好写多了。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">蠢</td>
+<td style="font-family:erjian,SimSun,serif">𧉾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">篡</td>
+<td style="font-family:erjian,SimSun,serif">篡</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">等</td>
+<td style="font-family:erjian,SimSun,serif">等</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鬼</td>
+<td style="font-family:erjian,SimSun,serif">鬼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">魔</td>
+<td style="font-family:erjian,SimSun,serif">魔</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">磨</td>
+<td style="font-family:erjian,SimSun,serif">磨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">摩</td>
+<td style="font-family:erjian,SimSun,serif">𭙕</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">阔</td>
+<td style="font-family:erjian,SimSun,serif">阔</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">旁</td>
+<td style="font-family:SimSun,serif">㝑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鼠</td>
+<td style="font-family:erjian,SimSun,serif">鼠</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">叟搜嗖飕</td>
+<td style="font-family:erjian,SimSun,serif">叟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">臾</td>
+<td style="font-family:SimSun,serif">㬰</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舀</td>
+<td style="font-family:erjian,SimSun,serif">舀</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">隋随</td>
+<td style="font-family:SimSun,serif">陏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">犀</td>
+<td style="font-family:erjian,SimSun,serif">𰠨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">喜</td>
+<td style="font-family:erjian,SimSun,serif">喜</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">雨</td>
+<td style="font-family:erjian,SimSun,serif">雨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舟</td>
+<td style="font-family:erjian,SimSun,serif">𠔾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">角</td>
+<td style="font-family:erjian,SimSun,serif">角</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">耳</td>
+<td style="font-family:erjian,SimSun,serif">耳</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">南</td>
+<td style="font-family:erjian,SimSun,serif">南</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">商</td>
+<td style="font-family:erjian,SimSun,serif">商</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">皿</td>
+<td style="font-family:erjian,SimSun,serif">皿</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">血</td>
+<td style="font-family:erjian,SimSun,serif">血</td>
+</tr>
+</table></div>
+</div>
+<center><h3>5．草书楷化字<small>（<span style="font-family:SimSun,serif">16个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">把行草书改成楷书的形式，可以减少较多笔画。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">弟第</td>
+<td style="font-family:erjian,SimSun,serif">弟</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">涕嚏</td>
+<td style="font-family:erjian,SimSun,serif">涕</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">亥</td>
+<td style="font-family:erjian,SimSun,serif">亥</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">柬</td>
+<td style="font-family:erjian,SimSun,serif">𫠣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">阑斓</td>
+<td style="font-family:erjian,SimSun,serif">阑</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">贸</td>
+<td style="font-family:erjian,SimSun,serif">贸</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">照</td>
+<td style="font-family:erjian,SimSun,serif">照</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">票</td>
+<td style="font-family:erjian,SimSun,serif">票</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">要</td>
+<td style="font-family:erjian,SimSun,serif">要</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">其</td>
+<td style="font-family:erjian,SimSun,serif">其</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">夏</td>
+<td style="font-family:erjian,SimSun,serif">夏</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">身</td>
+<td style="font-family:erjian,SimSun,serif">身</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">事</td>
+<td style="font-family:erjian,SimSun,serif">事</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">高</td>
+<td style="font-family:erjian,SimSun,serif">高</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">薛</td>
+<td style="font-family:erjian,SimSun,serif">薛</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">壹</td>
+<td style="font-family:erjian,SimSun,serif">壹</td>
+</tr>
+</table></div>
+</div>
+<center><h3>6．会意字<small>（<span style="font-family:SimSun,serif">6个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">用几个常用字（或偏旁）构成一个字，表示一个意思。例如<span style="font-family:erjian,SimSun,serif">𠆣</span>是寡的古体，“一人为寡”。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">矮</td>
+<td style="font-family:SimSun,serif">仦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">寡</td>
+<td style="font-family:erjian,SimSun,serif">𠆣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">集</td>
+<td style="font-family:SimSun,serif">亼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">家</td>
+<td style="font-family:erjian,SimSun,serif">𡦼</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">聚</td>
+<td style="font-family:erjian,SimSun,serif">聚</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">燃</td>
+<td style="font-family:erjian,SimSun,serif">𤆂</td>
+</tr>
+</table></div>
+</div>
+<center><h3>7．符号字<small>（<span style="font-family:SimSun,serif">5个</span>）</small></h3></center>
+<p style="font-family:SimSun,serif;text-indent:2em">把原字笔画繁难的部分，用简单的笔画（或字）代替。这些笔画（或字）在这类简化字中仅仅作为符号，不起表音表意作用。</p>
+<div style="column-width:8em;-moz-column-width:8em;-webkit-column-width:8em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">割</td>
+<td style="font-family:SimSun,serif">刈<sup id="ref-19"><a class="themed-link" href="#note-19">⑲</a></sup></td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">奥</td>
+<td style="font-family:erjian,SimSun,serif">𫤭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">粤</td>
+<td style="font-family:erjian,SimSun,serif">粤</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">韩</td>
+<td style="font-family:erjian,SimSun,serif">𨊣</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">魏</td>
+<td style="font-family:erjian,SimSun,serif">魏</td>
+</tr>
+</table></div>
+</div>
+<center><h3>8．简化偏旁</h3></center>
+<center><h4>（1）可作简化偏旁用的简化字<small>（<span style="font-family:SimSun,serif">24个</span>）</small></h4></center>
+<p style="font-family:SimSun,serif;text-indent:2em">24个可作简化偏旁用的简化字（均见第二表前七类），及可类推简化的字一幷列表如下。</p>
+<div style="column-width:15em;-moz-column-width:15em;-webkit-column-width:15em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+<td>可类推简化的字</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">敢</td>
+<td style="font-family:SimSun,serif">攼</td>
+<td style="font-family:SimSun,serif">橄 瞰 憨</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">既</td>
+<td style="font-family:SimSun,serif">旡</td>
+<td style="font-family:SimSun,serif">慨 溉 概</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">鬼</td>
+<td style="font-family:erjian,SimSun,serif">鬼</td>
+<td style="font-family:SimSun,serif">魁 魅 傀 愧 瑰 槐 魂 魄</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">旁</td>
+<td style="font-family:SimSun,serif">㝑</td>
+<td style="font-family:SimSun,serif">傍 谤 榜 膀 磅 镑 耪 螃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">喜</td>
+<td style="font-family:erjian,SimSun,serif">喜</td>
+<td style="font-family:SimSun,serif">嘻 嬉 禧 熹</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">叟</td>
+<td style="font-family:erjian,SimSun,serif">叟</td>
+<td style="font-family:SimSun,serif">馊 嫂 艘 瘦</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舀</td>
+<td style="font-family:erjian,SimSun,serif">舀</td>
+<td style="font-family:SimSun,serif">滔 韬</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">皿</td>
+<td style="font-family:erjian,SimSun,serif">皿</td>
+<td style="font-family:SimSun,serif">盂 孟 猛 锰 蜢 盅 盆 盐 盏 监 槛 褴 益 谥 溢 缢 盔 盛 盖 盗 盘 盟 温 蕴 磕 瞌 阖</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">血</td>
+<td style="font-family:erjian,SimSun,serif">血</td>
+<td style="font-family:SimSun,serif">衅 恤</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">商</td>
+<td style="font-family:erjian,SimSun,serif">商</td>
+<td style="font-family:SimSun,serif">熵</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">南</td>
+<td style="font-family:erjian,SimSun,serif">南</td>
+<td style="font-family:SimSun,serif">献 喃 楠 蝻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">耳</td>
+<td style="font-family:erjian,SimSun,serif">耳</td>
+<td style="font-family:SimSun,serif">耶 椰 取 娶 趣 最 撮 耻 耽 耿 聆 职 联 聘 聪 洱 饵 弭 聂 摄 镊 蹑 揖 缉 楫 辑 茸 耸 聋 闻</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">角</td>
+<td style="font-family:erjian,SimSun,serif">角</td>
+<td style="font-family:SimSun,serif">斛 触 桷 确 懈 蟹</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">舟</td>
+<td style="font-family:erjian,SimSun,serif">𠔾</td>
+<td style="font-family:SimSun,serif">舰 航 舷 舵 舸 舶 船 艄 艘 般 搬 瘢 磐 盘</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">雨</td>
+<td style="font-family:erjian,SimSun,serif">雨</td>
+<td style="font-family:SimSun,serif">雯 零 雾 雹 雷 擂 镭 需 懦 糯 震 霄 霉 霖 霎 霍 霓 露 酃</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">弟</td>
+<td style="font-family:erjian,SimSun,serif">弟</td>
+<td style="font-family:SimSun,serif">剃 梯 锑 递</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">高</td>
+<td style="font-family:erjian,SimSun,serif">高</td>
+<td style="font-family:SimSun,serif">敲 搞 槁 犒 稿 镐 蒿 篙</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">亥</td>
+<td style="font-family:erjian,SimSun,serif">亥</td>
+<td style="font-family:SimSun,serif">刻 该 咳 孩 骇 核 赅 骸 阂</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">柬</td>
+<td style="font-family:erjian,SimSun,serif">𫠣</td>
+<td style="font-family:SimSun,serif">谏 楝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">票</td>
+<td style="font-family:erjian,SimSun,serif">票</td>
+<td style="font-family:SimSun,serif">飘 瓢 漂 膘 瞟 镖 鳔</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">要</td>
+<td style="font-family:erjian,SimSun,serif">要</td>
+<td style="font-family:SimSun,serif">腰</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">其</td>
+<td style="font-family:erjian,SimSun,serif">其</td>
+<td style="font-family:SimSun,serif">期 欺 斯 嘶 撕 厮 淇 祺 棋 琪 基 箕 旗</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">身</td>
+<td style="font-family:erjian,SimSun,serif">身</td>
+<td style="font-family:SimSun,serif">躬 躯 躲 躺 射 谢 榭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">家</td>
+<td style="font-family:erjian,SimSun,serif">𡦼</td>
+<td style="font-family:SimSun,serif">嫁 稼</td>
+</tr>
+</table></div>
+</div>
+<center><h4>（2）不能单独成字的简化偏旁<small>（<span style="font-family:SimSun,serif">16个</span>）</small></h4></center>
+<p style="font-family:SimSun,serif;text-indent:2em">16个不能单独成字的简化偏旁（其中爿〔pán〕、豸〔zhì〕单用时保留原字；“厥”作单字用时简作“<span style="font-family:erjian,SimSun,serif">厥</span>”；“阑”作单字用时简作“<span style="font-family:erjian,SimSun,serif">阑</span>”，“阑尾”简作“兰尾”），及可类推简化的字一幷列表如下。</p>
+<div style="column-width:15em;-moz-column-width:15em;-webkit-column-width:15em">
+<div class="table-wrapper"><table>
+<tr>
+<td>原字</td>
+<td>简作</td>
+<td>可类推简化的字</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">爿</td>
+<td style="font-family:SimSun,serif">丬</td>
+<td style="font-family:SimSun,serif">寐</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">豸</td>
+<td style="font-family:SimSun,serif">犭</td>
+<td style="font-family:SimSun,serif">豺 豹 貂 貉</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">厥</td>
+<td style="font-family:SimSun,serif">夬</td>
+<td style="font-family:SimSun,serif">撅 橛 獗 蹶</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">阑</td>
+<td style="font-family:SimSun,serif">兰</td>
+<td style="font-family:SimSun,serif">镧</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">廴</td>
+<td style="font-family:SimSun,serif">⻌</td>
+<td style="font-family:SimSun,serif">廷 挺 延 涎 蜓 筵 犍 毽</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">衤</td>
+<td style="font-family:SimSun,serif">礻</td>
+<td style="font-family:SimSun,serif">补 初 衬 衫 袄 袜 袒 袖 袍 被 裆 裕 裙 裱 褂 裸 褪 褛 褶 褴</td>
+</tr>
+<tr>
+<td style="font-family:erjian,SimSun,serif">龺</td>
+<td style="font-family:SimSun,serif">车</td>
+<td style="font-family:SimSun,serif">朝 嘲 潮 戟 翰</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">尞</td>
+<td style="font-family:SimSun,serif">了</td>
+<td style="font-family:SimSun,serif">撩 獠 缭</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">尃</td>
+<td style="font-family:erjian,SimSun,serif">尃</td>
+<td style="font-family:SimSun,serif">博 搏 膊 缚 薄</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">啇</td>
+<td style="font-family:erjian,SimSun,serif">啇</td>
+<td style="font-family:SimSun,serif">摘 嘀 滴 嫡 镝</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">臽</td>
+<td style="font-family:erjian,SimSun,serif">臽</td>
+<td style="font-family:SimSun,serif">谄 陷 掐 馅 焰 </td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">隹</td>
+<td style="font-family:erjian,SimSun,serif">隹</td>
+<td style="font-family:SimSun,serif">准 谁 难 傩 摊 滩 瘫 堆 推 唯 帷 惟 淮 维 潍 椎 雅 稚 雏 碓 睢 锥 雌 榫 售 雀 雇 翟 霍 瞿 崔 催 摧 焦 憔 樵 礁 蕉 鹤 截 蔺 躏 雁 雍 壅 攫 暹 鹳 颧 獾</td>
+</tr>
+<tr>
+<td style="font-family:SimSun,serif">灬</td>
+<td style="font-family:SimSun,serif">一</td>
+<td style="font-family:SimSun,serif">杰 点 热 烈 羔 糕 羹 庶 鹧 蔗 遮 焘 烹 焉 煮 焦 憔 樵 礁 蕉 黑 默 黔 黝 黯 嘿 墨 熏 醺 煎 煦 煞 熬 熙 罴 熊 燕 熹</td>
+</tr>
+<tr>
+<td style="font-family:erjian,SimSun,serif">𥝢</td>
+<td style="font-family:SimSun,serif">利</td>
+<td style="font-family:SimSun,serif">黎 藜</td>
+</tr>
+<tr>
+<td style="font-family:erjian,SimSun,serif">癶</td>
+<td style="font-family:SimSun,serif">癶</td>
+<td style="font-family:SimSun,serif">祭</td>
+</tr>
+<tr>
+<td style="font-family:erjian,SimSun,serif">𠇍氽</td>
+<td style="font-family:SimSun,serif">尒</td>
+<td style="font-family:SimSun,serif">恭 慕 添 舔 黍 傣 黎 藜</td>
+</tr>
+</table></div>
+</div>
+<h4>注释</h4>
+<ol class="circled-ol">
+<li id="note-1"><a class="themed-link" href="#ref-1">↑</a> 中药秦艽的艽仍读jiāo。</li>
+<li id="note-2"><a class="themed-link" href="#ref-2">↑</a> 中药桔梗的桔仍读jié。</li>
+<li id="note-3"><a class="themed-link" href="#ref-3">↑</a> 潦草、潦倒的潦简作了，用作“雨水大”义读lào时改用涝。</li>
+<li id="note-4"><a class="themed-link" href="#ref-4">↑</a> 伶仃的仃仍读dīng。</li>
+<li id="note-5"><a class="themed-link" href="#ref-5">↑</a> 迂回的迂仍读yū。</li>
+<li id="note-6"><a class="themed-link" href="#ref-6">↑</a> 咀嚼的咀仍读jǔ。</li>
+<li id="note-7"><a class="themed-link" href="#ref-7">↑</a> 雕刻的雕简作刁，老雕的雕简作<span style="font-family:erjian,SimSun,serif">𩾗</span>。</li>
+<li id="note-8"><a class="themed-link" href="#ref-8">↑</a> 旅的旁容易写错。膂本作吕，象脊梁骨之形。</li>
+<li id="note-9"><a class="themed-link" href="#ref-9">↑</a> 渲染的渲和宣合并简作㝉，以免同演—<span style="font-family:erjian,SimSun,serif">𰛑</span>相混。</li>
+<li id="note-10"><a class="themed-link" href="#ref-10">↑</a> 肥沃的沃仍读wò。</li>
+<li id="note-11"><a class="themed-link" href="#ref-11">↑</a> 贮藏的贮原读zhù，现在一般都读chǔ，故与同义字储一并简作㑁。</li>
+<li id="note-12"><a class="themed-link" href="#ref-12">↑</a> 蛈仿迭跌等字。</li>
+<li id="note-13"><a class="themed-link" href="#ref-13">↑</a> <span style="font-family:erjian,SimSun,serif">𰰤</span>仿沤欧等字，区作声旁读ou。</li>
+<li id="note-14"><a class="themed-link" href="#ref-14">↑</a> <span style="font-family:erjian,SimSun,serif">臀</span>仿尾屁等字，屯作声旁。</li>
+<li id="note-15"><a class="themed-link" href="#ref-15">↑</a> 嫌是贬义字故女旁改用竖心旁，简作<span style="font-family:erjian,SimSun,serif">𢙝</span>。</li>
+<li id="note-16"><a class="themed-link" href="#ref-16">↑</a> 元素的钆仍读gá。</li>
+<li id="note-17"><a class="themed-link" href="#ref-17">↑</a> 弗许的弗仍读fú。</li>
+<li id="note-18"><a class="themed-link" href="#ref-18">↑</a> 没与设形近，“没有”“设有”易混，需要区别。古兵器的殳仍读shū。</li>
+<li id="note-19"><a class="themed-link" href="#ref-19">↑</a> 删刈、刈除等的刈仍读yì。</li>
+</ol>
+</section>
+<footer class="article-footer">
+<section class="article-tags">
+<a href="/tags/%E7%94%B5%E5%AD%90%E5%8C%96/">电子化</a>
+</section>
+</footer>
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/katex@0.15.6/dist/katex.min.css" integrity="sha256-J+iAE0sgH8QSz9hpcDxXIftnj65JEZgNhGcgReTTK9s=" rel="stylesheet"/>
+<script crossorigin="anonymous" defer="" integrity="sha256-InsNdER1b2xUewP+pKCUJpkhiqwHgqiPXDlIk7GzBu4=" src="https://cdn.jsdelivr.net/npm/katex@0.15.6/dist/katex.min.js"></script>
+<script crossorigin="anonymous" defer="" integrity="sha256-y39Mpg7V3D4lhBX4x6O0bUqTV4pSrfgwEfGKfxkOdgI=" src="https://cdn.jsdelivr.net/npm/katex@0.15.6/dist/contrib/auto-render.min.js"></script>
+<script>window.addEventListener("DOMContentLoaded",(()=>{renderMathInElement(document.querySelector(".article-content"),{delimiters:[{left:"$$",right:"$$",display:!0},{left:"$",right:"$",display:!1},{left:"\\(",right:"\\)",display:!1},{left:"\\[",right:"\\]",display:!0}],macros:{"\\upalpha":"\\text{α}","\\upbeta":"\\text{β}","\\upgamma":"\\text{γ}","\\updelta":"\\text{δ}","\\upepsilon":"\\text{ϵ}","\\upvarepsilon":"\\text{ε}","\\upzeta":"\\text{ζ}","\\upeta":"\\text{η}","\\uptheta":"\\text{θ}","\\upvartheta":"\\text{ϑ}","\\upiota":"\\text{ι}","\\upkappa":"\\text{κ}","\\uplambda":"\\text{λ}","\\upmu":"\\text{μ}","\\upnu":"\\text{ν}","\\upxi":"\\text{ξ}","\\upomicron":"\\text{ο}","\\uppi":"\\text{π}","\\uprho":"\\text{ρ}","\\upvarrho":"\\text{ϱ}","\\upsigma":"\\text{σ}","\\upvarsigma":"\\text{ς}","\\uptau":"\\text{τ}","\\upupsilon":"\\text{υ}","\\upphi":"\\text{ϕ}","\\upvarphi":"\\text{φ}","\\upchi":"\\text{χ}","\\uppsi":"\\text{ψ}","\\upomega":"\\text{ω}","\\uppartial":"\\text{∂}"}})}));</script>
+</article>
+<aside class="related-content--wrapper"><h2 class="section-title">相关文章</h2><div class="related-content"><div class="flex article-list--tile">
+<article class="has-image">
+<a href="/p/bafu/"><div class="article-image"><img alt="Featured image of post 信息技术 信息交换用汉字编码字符集 第八辅助集" data-hash="md5-dL9g9UkttXYzUJRHZsABCw==" height="150" loading="lazy" src="/p/bafu/bafu-1.74bf60f5492db5763350944766c0010b_hu726f26105106f74486478a1eb65d6ccf_81818_250x150_fill_box_smart1_3.png" width="250"/></div><div class="article-details"><h2 class="article-title">信息技术 信息交换用汉字编码字符集 第八辅助集</h2></div></a>
+</article>
+<article class="has-image">
+<a href="/p/erjian-xiuding-cao/"><div class="article-image"><img alt="Featured image of post 第二次汉字简化方案修订草案征求意见表" data-hash="md5-sxRMss3Vxz8KJU3TjFoAIw==" height="150" loading="lazy" src="/p/erjian-xiuding-cao/erjianx-1.b3144cb2cdd5c73f0a254dd38c5a0023_hu4dcaf662c147d73f1c02846415982b4b_30064_250x150_fill_q100_box_smart1.jpg" width="250"/></div><div class="article-details"><h2 class="article-title">第二次汉字简化方案修订草案征求意见表</h2></div></a>
+</article>
+<article class="has-image">
+<a href="/p/dianma-ben/"><div class="article-image"><img alt="Featured image of post 标准电码本" data-hash="md5-/OgyDU2kAddpd4clwpFJ5g==" height="150" loading="lazy" src="/p/dianma-ben/dmb-1.fce8320d4da401d769778725c29149e6_hu4bf16e8cc370f8c6eb83319580543ea3_39706_250x150_fill_box_smart1_3.png" width="250"/></div><div class="article-details"><h2 class="article-title">标准电码本</h2></div></a>
+</article>
+<article class="">
+<a href="/p/l3-fonts/"><div class="article-details"><h2 class="article-title">哪些字体支持GB 18030-2022实现级别3？</h2></div></a>
+</article>
+<article class="has-image">
+<a href="/p/apple-18030/"><div class="article-image"><img alt="Featured image of post 锐🍎国标第十平面" data-hash="md5-nlzwphfP+53OW353bVu7Bg==" height="150" loading="lazy" src="/p/apple-18030/apple-1.9e5cf0a617cffb9dce5b7e776d5bbb06_hu35ec09f6d6dc125abfab42386d5f2574_37572_250x150_fill_box_smart1_3.png" width="250"/></div><div class="article-details"><h2 class="article-title">锐🍎国标第十平面</h2></div></a>
+</article>
+</div></div></aside>
+<div id="gitalk-container"></div>
+<script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/blueimp-md5@2.18.0/js/md5.min.js"></script>
+<script>gitalk=new Gitalk({clientID:"4c243dc52ffe119cd15f",clientSecret:"886ddf6875b4e153196f12e011ab9477c8db556c",repo:"gitalk-comments",owner:"Honoka55",admin:["Honoka55"],distractionFreeMode:!1,id:md5(location.pathname),language:'zh-CN'}),-1==["localhost","127.0.0.1"].indexOf(window.location.hostname)?gitalk.render("gitalk-container"):document.getElementById("gitalk-container").innerHTML="Gitalk comments not available by default when the website is previewed locally.";</script>
+<footer class="site-footer">
+<section class="copyright"><a href="/LICENSE.txt" rel="noopener" target="_blank">🅭🅯4.0</a> 2019-2026 焰华Honoka55</section>
+<section class="powerby">Built with <a href="https://gohugo.io/" rel="noopener" target="_blank">Hugo</a> <br/>Theme <b><a data-version="3.14.0" href="https://github.com/CaiJimmy/hugo-theme-stack" rel="noopener" target="_blank">Stack</a></b> designed by <a href="https://jimmycai.com" rel="noopener" target="_blank">Jimmy</a></section>
+<button class="top-button" id="top-button" onclick="smoothScrollTop()">⬆ TOP</button>
+</footer>
+<div aria-hidden="true" class="pswp" role="dialog" tabindex="-1"><div class="pswp__bg"></div><div class="pswp__scroll-wrap"><div class="pswp__container"><div class="pswp__item"></div><div class="pswp__item"></div><div class="pswp__item"></div></div><div class="pswp__ui pswp__ui--hidden"><div class="pswp__top-bar"><div class="pswp__counter"></div><button class="pswp__button pswp__button--close" title="Close (Esc)"></button><button class="pswp__button pswp__button--share" title="Share"></button><button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button><button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button><div class="pswp__preloader"><div class="pswp__preloader__icn"><div class="pswp__preloader__cut"><div class="pswp__preloader__donut"></div></div></div></div></div><div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap"><div class="pswp__share-tooltip"></div></div><button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button><button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button><div class="pswp__caption"><div class="pswp__caption__center"></div></div></div></div></div>
+<script crossorigin="anonymous" defer="" integrity="sha256-ePwmChbbvXbsO02lbM3HoHbSHTHFAeChekF1xKJdleo=" src="https://cdn.jsdelivr.net/npm/photoswipe@4.1.3/dist/photoswipe.min.js"></script>
+<script crossorigin="anonymous" defer="" integrity="sha256-UKkzOn/w1mBxRmLLGrSeyB4e1xbrp4xylgAWb3M42pU=" src="https://cdn.jsdelivr.net/npm/photoswipe@4.1.3/dist/photoswipe-ui-default.min.js"></script>
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/photoswipe@4.1.3/dist/default-skin/default-skin.min.css" rel="stylesheet"/>
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/photoswipe@4.1.3/dist/photoswipe.min.css" rel="stylesheet"/>
+</main>
+</div>
+<script crossorigin="anonymous" integrity="sha256-awcR2jno4kI5X0zL8ex0vi2z+KMkF24hUW8WePSA9HM=" src="https://cdn.jsdelivr.net/npm/node-vibrant@3.1.6/dist/vibrant.min.js"></script><script defer="" src="/ts/main.js" type="text/javascript"></script>
+<script>!function(){const e=document.createElement("link");e.href="https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@400;700&text=ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔゕゖ゙゚゛゜ゝゞゟ゠ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴヵヶヷヸヹヺ・ーヽヾヿㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ𛀀𛀁&display=swap",e.type="text/css",e.rel="stylesheet",document.head.appendChild(e)}();</script>
+<script crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@twemoji/api@latest/dist/twemoji.min.js"></script>
+<script>twemoji.parse(document.body,{callback:function(c,e,t){switch(c){case"203c":case"2049":return!1}return"".concat(e.base,e.size,"/",c,e.ext)}});</script>
+<script>function scrollTopButton(){document.getElementById("top-button").style.display=document.body.scrollTop>20||document.documentElement.scrollTop>20?"block":"none"}function smoothScrollTop(){let o=null;cancelAnimationFrame(o),o=requestAnimationFrame((function n(){let t=document.body.scrollTop||document.documentElement.scrollTop;t>0?(document.body.scrollTop=document.documentElement.scrollTop=t-50,o=requestAnimationFrame(n)):cancelAnimationFrame(o)}))}window.onscroll=function(){scrollTopButton()};</script>
+</body>
+</html>

--- a/.sources/honoka55/erjian-cao/2026-07-10/manifest.json
+++ b/.sources/honoka55/erjian-cao/2026-07-10/manifest.json
@@ -1,0 +1,24 @@
+{
+  "source": "焰华Honoka55 个人网站电子化版（Hugo 生成页面）",
+  "work": "第二次汉字简化方案（草案）",
+  "fetched_at": "2026-07-10T17:00:00-07:00",
+  "files": [
+    {
+      "file": "index.html",
+      "url": "https://honoka55.github.io/p/erjian-cao/",
+      "raw_url": "https://raw.githubusercontent.com/Honoka55/honoka55.github.io/master/p/erjian-cao/index.html",
+      "versioned_raw_url": "https://raw.githubusercontent.com/Honoka55/honoka55.github.io/3d46fb7587796b8f38e60213ea419a8a10ba63b3/p/erjian-cao/index.html",
+      "upstream_commit": "3d46fb7587796b8f38e60213ea419a8a10ba63b3",
+      "upstream_commit_date": "2026-01-30T16:44:56Z"
+    },
+    {
+      "file": "erjian.ttf",
+      "comment": "电子化版专用字体：将 Unicode 未收录的二简字形映射到其借用的标准码位（113 个 BMP 码位为变形字形，另含扩展区二简字标准字形）。生僻字图即由此字体渲染。",
+      "url": "https://cdn.jsdelivr.net/gh/Honoka55/honoka55.github.io/fonts/erjian.ttf",
+      "versioned_raw_url": "https://raw.githubusercontent.com/Honoka55/honoka55.github.io/978b61bf9ad1f0f63b1917107de2e2dbf048bd89/fonts/erjian.ttf",
+      "upstream_commit": "978b61bf9ad1f0f63b1917107de2e2dbf048bd89",
+      "upstream_commit_date": "2023-09-15T02:06:34Z"
+    }
+  ],
+  "notes": "原文件为 1977 年 5 月中国文字改革委员会《第二次汉字简化方案（草案）》。字形甄别：erjian.ttf cmap 中 118 个 BMP 码位里，一（U+4E00）、桜（U+685C）、浂（U+6D42）、肊（U+808A）、氽（U+6C3D）5 字与标准字形一致（对照 Jigmo 字形逐一目检），其余 113 字为二简变形字形，转换时以 rare-char 字形图呈现。"
+}

--- a/现代作品/第二次汉字简化方案（草案）.md
+++ b/现代作品/第二次汉字简化方案（草案）.md
@@ -1,0 +1,669 @@
+---
+title:
+  zh-hans: 第二次汉字简化方案（草案）
+  zh-hant: 第二次漢字簡化方案（草案）
+author: 中国文字改革委员会
+category: /现代作品
+lastmod: 2026-07-10T18:00:00-07:00
+github_repo_url: https://github.com/frankslin/daizhigev20/blob/data/%E7%8E%B0%E4%BB%A3%E4%BD%9C%E5%93%81/%E7%AC%AC%E4%BA%8C%E6%AC%A1%E6%B1%89%E5%AD%97%E7%AE%80%E5%8C%96%E6%96%B9%E6%A1%88%EF%BC%88%E8%8D%89%E6%A1%88%EF%BC%89.md
+daizhige_url: https://daizhige.org/%E7%8E%B0%E4%BB%A3%E4%BD%9C%E5%93%81/%E7%AC%AC%E4%BA%8C%E6%AC%A1%E6%B1%89%E5%AD%97%E7%AE%80%E5%8C%96%E6%96%B9%E6%A1%88%EF%BC%88%E8%8D%89%E6%A1%88%EF%BC%89.html
+source: 焰华Honoka55 电子化版
+source_url: https://honoka55.github.io/p/erjian-cao/
+additional_info:
+  - 1977年5月中国文字改革委员会发表，1978年停止试用，1986年6月国务院批准废止
+  - 2026-07-10 转换自「焰华Honoka55」电子化网页版；Unicode 未收录的二简字形（110 个）以字形图呈现，摹自底本专用字体
+---
+
+## 说明
+
+　　**一、草案为什么分两个表？**
+
+　　这是因为两个表所收简化字的流行情况不同。
+
+　　第一表所收的简化字已在全国流行，可在出版物上先行试用。
+
+　　第二表所收的简化字有三种情况：（一）已在部分地区或某个行业中流行。这类字占大多数。（二）有些字是从社会上流行的几种不同简体中选用的，选用得是否合适，还需要讨论。这类字占一小部分。（三）还有少数字，原字笔画较繁而又比较常用，是我们根据群众简化汉字的方法拟订的。因此，第二表的简化字，需要经过群众广泛讨论，提出修改、增补或者删除的意见。
+
+　　**二、草案一共收了多少简化字？**
+
+　　第一表收简化字193个（其中不作简化偏旁的简化字172个，可作简化偏旁的简化字21个）；类推出来的简化字55个。以上两项合计，共248个。
+
+　　第二表收简化字269个（其中不作简化偏旁的简化字245个，可作简化偏旁的简化字24个）；此外，不能单独成字的简化偏旁16个。根据24个可作简化偏旁的简化字和16个不能单独成字的简化偏旁，类推出来的简化字336个。以上两项合计，共605个。
+
+　　整个草案，共收简化字853个，简化偏旁61个。
+
+　　在精简汉字数量方面，草案精简了263个字。
+
+　　**三、草案中的类推字是在什么范围內类推简化的？**
+
+　　按说，一个偏旁简化了，所有包含这个偏旁的字都应该同样简化。但是，考虑到汉字总数很多，其中有很大一部分是死字、古字，现代汉语中已经不用，没有必要把所有可以类推的字全部类推简化。因此，草案中的类推简化字，暂在4500个较常用字范围内类推简化。
+
+　　**四、还有哪些字急需简化？**
+
+　　这次简化以后，在4500个较常用字中，超过十笔的还有1300字。其中使用频率较高而急需简化的字举例如下：
+
+　　衡　醒　酷　增　横　题　篇　端　缩　豪　群　溪　御　融　蹄　赠　薪　操　额　醋　嫩　嗽　辣　撇　誓　舅　嗅　赖　罩　缴　慧　隔　谨　捷　滞　骡　纂　攥　撑　鳞　蹦　髓
+
+　　此外，还有一些笔画不算多，但是难写难读或容易写错读错的字，也需要在简化过程中求得解决。
+
+　　这些字怎样简化，希望大家研究讨论。
+
+　　中国文字改革委员会
+
+　　1977年5月
+
+## 第一表
+
+### （1）不作简化偏旁的简化字（172个）
+
+| 原字 | 简作 |
+| --- | --- |
+| 懊 | 㤇 |
+| 芭笆粑 | 巴 |
+| 帮 | 邦 |
+| 爆 | 𤆊 |
+| 蓖篦蔽 | 芘 |
+| 弊 | 𰐉 |
+| 壁 | 坒 |
+| 萹藊稨 | 扁 |
+| 摒 | 屏 |
+| 病 | 疒 |
+| 播 | 抪 |
+| 部 | 𰆊 |
+| 彩 | 采 |
+| 菜蔡 | 𦬁 |
+| 餐 | 歺 |
+| 舱 | 仓 |
+| 藏 | 䒙 |
+| 衩扠杈汊 | 叉 |
+| 撤 | 𢪃 |
+| 瞅 | 𥄨 |
+| 矗 | 𰅹 |
+| 葱 | 茐 |
+| 答 | 荅 |
+| 蛋 | 旦 |
+| 弹 | 𰐔 |
+| 蹈 | 𰸁 |
+| 稻 | 𰨛 |
+| 道 | 辺 |
+| 殿 | 𡱒 |
+| 叮盯钉靪 | 丁 |
+| 董 | 苳 |
+| 懂 | 㤏 |
+| 短 | 𰦓 |
+| 蹲 | 𧿬 |
+| 燉 | 炖 |
+| 贰 | 弍 |
+| 愤 | 忿 |
+| 孵 | 孚 |
+| 伕 | 夫 |
+| 富 | 𫲷 |
+| 副 | 付 |
+| 秆竿 | 杆 |
+| 钩 | 勾 |
+| 罐 | 𰭃 |
+| 灌盥 | 浂 |
+| 鳜 | 桂 |
+| 裹 | 果 |
+| 薅 | 䒵 |
+| 盒 | 合 |
+| 葫猢蝴糊 | 胡 |
+| 毁 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6BC1-erjian.png" alt="二简字形（借「毁」字位）" title="二简字形，Unicode 未收录；借用 U+6BC1「毁」字位，摹自底本专用字体"> |
+| 籍 | 笈 |
+| 建 | 迠 |
+| 豇 | 江 |
+| 酱 | 𪧷 |
+| 跤 | 交 |
+| 椒 | 茭 |
+| 街 | 亍 |
+| 阱 | 井 |
+| 境 | 㘫 |
+| 镜 | 𰽟 |
+| 韭 | 艽[^1] |
+| 酒 | 氿 |
+| 橘 | 桔[^2] |
+| 镢䦆 | 𰽤 |
+| 慷 | 忼 |
+| 糠 | 粇 |
+| 靠 | 俈 |
+| 款 | 𤘯 |
+| 蓝篮 | 兰 |
+| 澜滥 | 㳕 |
+| 谰 | 𰵟 |
+| 懒 | 𰑐 |
+| 缆 | 𰬊 |
+| 磊 | 𰦫 |
+| 荔 | 艻 |
+| 璃 | 玏 |
+| 量 | 𰅊 |
+| 潦 | 了[^3] |
+| 僚 | 𠆨 |
+| 燎 | 𰝶 |
+| 寮寥 | 㝋 |
+| 廖 | 𭙏 |
+| 磷 | 砱 |
+| 龄 | 令 |
+| 溜遛熘馏 | 𰜈 |
+| 掳 | 虏 |
+| 慢 | 𭜌 |
+| 帽 | 𫷀 |
+| 貌 | 皃 |
+| 煤 | 𭳿 |
+| 幕 | 𫯜 |
+| 酿 | 𰼃 |
+| 虐 | 𰀂 |
+| 漆 | 㲺 |
+| 歧 | 岐 |
+| 器 | 𫩏 |
+| 谦 | 𰵋 |
+| 潜 | 汘 |
+| 歉 | 欠 |
+| 墙 | 垟 |
+| 勤 | 𰅉 |
+| 渠 | 洰 |
+| 嚷 | 𠮵 |
+| 壤 | 圵 |
+| 儒 | 𰁡 |
+| 赛 | 𡧳 |
+| 煽搧 | 扇 |
+| 绱鞝 | 上 |
+| 杓 | 勺 |
+| 输 | 𰹰 |
+| 爽 | 𰋜 |
+| 私 | 厶 |
+| 算 | 祘 |
+| 泰 | 太 |
+| 檀 | 枟 |
+| 糖 | 𰪩 |
+| 套 | 𰋛 |
+| 腾 | 𱅑 |
+| 停 | 仃[^4] |
+| 稳 | 𮂹 |
+| 舞 | 午 |
+| 稀 | 希 |
+| 熄 | 息 |
+| 瞎 | 𰥌 |
+| 镶 | 𰽙 |
+| 橡 | 𬂭 |
+| 萧 | 肖 |
+| 鞋 | 𰆻 |
+| 信 | 伩 |
+| 雄 | 厷 |
+| 修 | 㣊 |
+| 宣 | 㝉 |
+| 癣 | 㾌 |
+| 靴 | 𰆳 |
+| 雪 | 彐 |
+| 阎 | 闫 |
+| 演 | 𰛑 |
+| 耀曜 | 𭀦 |
+| 意 | 𰐺 |
+| 臆 | 肊 |
+| 翼 | 𰭝 |
+| 迎 | 迊 |
+| 影 | 𢒈 |
+| 臃 | 𦙸 |
+| 游 | 沋 |
+| 愉 | 𢖳 |
+| 遇 | 迂[^5] |
+| 预豫 | 予 |
+| 圆 | 元 |
+| 原 | 𰆖 |
+| 源 | 沅 |
+| 缘 | 𰫾 |
+| 赞 | 𰷣 |
+| 寨 | 𰌻 |
+| 账 | 帐 |
+| 辙 | 𰹹 |
+| 整 | 𰋞 |
+| 籽 | 子 |
+| 嘴 | 咀[^6] |
+| 座 | 坐 |
+
+| 原字 | 简作 |
+| --- | --- |
+| 哔叽 | 毕几 |
+| 枓栱 | 斗拱 |
+| 咔叽 | 卡几 |
+| 蝌蚪 | 科斗 |
+| 曚昽<br>朦胧<br>蒙眬 | 𰰡龙 |
+| 霹雳 | 辟历 |
+| 蚯蚓 | 丘引 |
+
+### （2）可作简化偏旁用的简化字（21个）
+
+| 原字 | 简作 | 类推出来的简化字 |
+| --- | --- | --- |
+| 鼻 | 𢍂 | 鼾—𰯶 |
+| 察嚓 | 𰌵 | 擦—𰓣 |
+| 感 | 𫹯 | 撼—𰓭，憾—𰑞 |
+| 冀 | 丠 | 骥—𱅌 |
+| 具 | 𰋙 | 俱—𰁬，惧—𰑌，<br>犋—𰠱 |
+| 留 | 畄 | 榴—𰗶，瘤—𰣲 |
+| 眉嵋 | 𠃜 | 媚—𰋻 |
+| 蒙 | 𰰡 | 蠓—𰲽 |
+| 面 | 𫩑 | 缅—𰬄 |
+| 囊囔 | 𰀉 | 攮—𰓌 |
+| 青 | 𰀈 | 静—𰁓，靛—𰍎，<br>请—𰵕，猜—𰡂，<br>情—𰑊，清—𰛓，<br>晴—𰕺，睛—𰥕，<br>靖—𰩢，精—𰪱，<br>菁—𰰫 |
+| 桑 | 𰗑 | 搡—𰓨，嗓—𰇢 |
+| 属 | 𰍱 | 嘱—𰇰，瞩—𰥩 |
+| 堂 | 坣 | 螳—𰳇 |
+| 易 | 𠃓 | 剔—𰄝，惕—𰐿，<br>赐—𰷟，锡—钖，<br>踢—𰸄 |
+| 婴 | 𰋷 | 缨—𰬕，樱—桜 |
+| 展辗 | 𰍰 | 碾—𰦪 |
+| 真 | 𰅴 | 颠—𱂪，填—𰉰，<br>慎—𰑝，滇—𰛬，<br>镇—𰾂 |
+| 直 | 𰅰 | 值—𰁲，植—𰗝，<br>殖—𰙽，置—𰭋 |
+| 卒 | 卆 | 悴—忰，啐—𠯥，<br>碎—砕，粹—粋，<br>醉—酔，翠—翆，<br>瘁—疩 |
+| 尊 | 𰃝 | 撙—𰓢 |
+
+## 第二表
+
+　　第二表的简化字，按不同的简化方法分为七类。第八类是简化偏旁及可类推简化的字。
+
+### 1．同音代替字（72个）
+
+　　在现代汉语中不引起意义混淆的条件下，用笔画简单的同音字，代替笔画较繁的字。例如，以“发”代“髮”，以“范”代“範”。也就是两个或两个以上的同音字，合幷成一个字。这样，旣简化了字形，又精简了字数。
+
+| 原字 | 简作 |
+| --- | --- |
+| 癍 | 斑 |
+| 鞭 | 卞 |
+| 辩辨辫 | 弁 |
+| 勃渤脖饽 | 孛 |
+| 簸 | 波 |
+| 澈 | 彻 |
+| 蹙 | 促 |
+| 戴 | 代 |
+| 巅癫 | 𱂪 |
+| 凋碉雕 | 刁[^7] |
+| 陡 | 斗 |
+| 嘟 | 都 |
+| 锻 | 煅 |
+| 墩礅蹾撉 | 敦 |
+| 筏阀垡 | 伐 |
+| 袱匐 | 伏 |
+| 傅 | 付 |
+| 擀 | 赶 |
+| 赣 | 干 |
+| 捍 | 扞 |
+| 寰 | 环 |
+| 徽 | 辉 |
+| 嫉 | 忌 |
+| 捡 | 拣 |
+| 嚼 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u564D-erjian.png" alt="二简字形（借「噍」字位）" title="二简字形，Unicode 未收录；借用 U+564D「噍」字位，摹自底本专用字体"> |
+| 诫 | 戒 |
+| 襟 | 𥘞 |
+| 飓 | 巨 |
+| 筐框眶诓哐 | 匡 |
+| 镰 | 连 |
+| 镣 | 钌 |
+| 镏 | 𰜈 |
+| 噜 | 鲁 |
+| 旅膂 | 吕[^8] |
+| 湄楣鹛 | 𠃜 |
+| 蜜密 | 宓 |
+| 藐 | 秒 |
+| 凝 | 泞 |
+| 襻 | 𥘽 |
+| 僻 | 辟 |
+| 拚 | 拼 |
+| 柒 | 㲺 |
+| 签 | 佥 |
+| 砂 | 沙 |
+| 墒 | 垧 |
+| 蒜 | 祘 |
+| 镗嘡膛 | 坣 |
+| 霆庭 | 𨑳 |
+| 童 | 仝 |
+| 豌 | 宛 |
+| 诿萎痿 | 委 |
+| 慰 | 尉 |
+| 鑫 | 欣 |
+| 胸 | 匈 |
+| 渲 | 㝉[^9] |
+| 檐 | 沿 |
+| 颜 | 彦 |
+| 赢 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u76C8-erjian.png" alt="二简字形（借「盈」字位）" title="二简字形，Unicode 未收录；借用 U+76C8「盈」字位，摹自底本专用字体"> |
+| 榨 | 乍 |
+| 蘸 | 沾 |
+| 骤 | 驺 |
+| 谘 | 咨 |
+| 鬃 | 骔 |
+| 遵 | 𰃝 |
+
+| 原字 | 简作 |
+| --- | --- |
+| 叮咛 | 丁宁 |
+| 哆嗦 | 多索 |
+| 吩咐 | 分付 |
+| 疙瘩<br>圪垯<br>纥𫄤 | 咯嗒 |
+| 鬎鬁 | 瘌<img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u75E2-erjian.png" alt="二简字形（借「痢」字位）" title="二简字形，Unicode 未收录；借用 U+75E2「痢」字位，摹自底本专用字体"> |
+| 阑尾 | 兰尾 |
+| 嘹喨 | 辽亮 |
+| 蹓跶 | 𰜈达 |
+| 罗嗦/噜苏 | 罗索 |
+| 柠檬 | 宁𰰡 |
+| 磅礴 | 㝑<img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8584-erjian.png" alt="二简字形（借「薄」字位）" title="二简字形，Unicode 未收录；借用 U+8584「薄」字位，摹自底本专用字体"> |
+| 彷徨/徬徨 | 㝑皇 |
+| 蜻蜓 | 𰀈𨑳 |
+| 舢舨 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8222-erjian.png" alt="二简字形（借「舢」字位）" title="二简字形，Unicode 未收录；借用 U+8222「舢」字位，摹自底本专用字体">板 |
+| 鹦鹉 | 𰋷武 |
+
+### 2．形声字（115个）
+
+　　汉字中绝大部分是形声字，例如“忠”字的“心”称为“形旁”，是表示字义的；“中”称为“声旁”，是表示字音的。运用“形声”结构来简化，有下列几种情况：原字的形旁、声旁笔画太繁，改用笔画较简的形体；原字声旁表音不准，改用表音较准的常用字作声旁。原字本来不是形声字而笔画较繁，改用笔画较简的新形声字。
+
+| 原字 | 简作 |
+| --- | --- |
+| 澳 | 沃[^10] |
+| 霸 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9738-erjian.png" alt="二简字形（借「霸」字位）" title="二简字形，Unicode 未收录；借用 U+9738「霸」字位，摹自底本专用字体"> |
+| 瓣 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u74E3-erjian.png" alt="二简字形（借「瓣」字位）" title="二简字形，Unicode 未收录；借用 U+74E3「瓣」字位，摹自底本专用字体"> |
+| 曝暴 | 𣅃 |
+| 瀑浦 | 𣱶 |
+| 鄙 | 𨚍 |
+| 避 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u907F-erjian.png" alt="二简字形（借「避」字位）" title="二简字形，Unicode 未收录；借用 U+907F「避」字位，摹自底本专用字体"> |
+| 簿 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7C3F-erjian.png" alt="二简字形（借「簿」字位）" title="二简字形，Unicode 未收录；借用 U+7C3F「簿」字位，摹自底本专用字体"> |
+| 锄 | 𨱄 |
+| 储贮 | 㑁[^11] |
+| 戳 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6233-erjian.png" alt="二简字形（借「戳」字位）" title="二简字形，Unicode 未收录；借用 U+6233「戳」字位，摹自底本专用字体"> |
+| 诞 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8BDE-erjian.png" alt="二简字形（借「诞」字位）" title="二简字形，Unicode 未收录；借用 U+8BDE「诞」字位，摹自底本专用字体"> |
+| 捣 | 㧅 |
+| 雕 | 𩾗 |
+| 蝶 | 蛈[^12] |
+| 蠹 | 𫊥 |
+| 翻 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7FFB-erjian.png" alt="二简字形（借「翻」字位）" title="二简字形，Unicode 未收录；借用 U+7FFB「翻」字位，摹自底本专用字体"> |
+| 繁 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7E41-erjian.png" alt="二简字形（借「繁」字位）" title="二简字形，Unicode 未收录；借用 U+7E41「繁」字位，摹自底本专用字体"> |
+| 逢 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9022-erjian.png" alt="二简字形（借「逢」字位）" title="二简字形，Unicode 未收录；借用 U+9022「逢」字位，摹自底本专用字体"> |
+| 缝 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7F1D-erjian.png" alt="二简字形（借「缝」字位）" title="二简字形，Unicode 未收录；借用 U+7F1D「缝」字位，摹自底本专用字体"> |
+| 敷 | 𪯈 |
+| 敢 | 攼 |
+| 焊 | 㶥 |
+| 壑 | 垥 |
+| 激 | 㲹 |
+| 稽嵇 | 𬓠 |
+| 假 | 𬽥 |
+| 简 | 𫈉 |
+| 健 | 伣 |
+| 键 | 𰽢 |
+| 耩 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8029-erjian.png" alt="二简字形（借「耩」字位）" title="二简字形，Unicode 未收录；借用 U+8029「耩」字位，摹自底本专用字体"> |
+| 剿 | 𠜅 |
+| 警儆 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8B66-erjian.png" alt="二简字形（借「警」字位）" title="二简字形，Unicode 未收录；借用 U+8B66「警」字位，摹自底本专用字体"> |
+| 厩 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53A9-erjian.png" alt="二简字形（借「厩」字位）" title="二简字形，Unicode 未收录；借用 U+53A9「厩」字位，摹自底本专用字体"> |
+| 厥 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53A5-erjian.png" alt="二简字形（借「厥」字位）" title="二简字形，Unicode 未收录；借用 U+53A5「厥」字位，摹自底本专用字体"> |
+| 裤 | 䃿 |
+| 篱 | 竻 |
+| 犁 | 牞 |
+| 痢 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u75E2-erjian.png" alt="二简字形（借「痢」字位）" title="二简字形，Unicode 未收录；借用 U+75E2「痢」字位，摹自底本专用字体"> |
+| 砾 | 劯 |
+| 律 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5F8B-erjian.png" alt="二简字形（借「律」字位）" title="二简字形，Unicode 未收录；借用 U+5F8B「律」字位，摹自底本专用字体"> |
+| 率 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7387-erjian.png" alt="二简字形（借「率」字位）" title="二简字形，Unicode 未收录；借用 U+7387「率」字位，摹自底本专用字体"> |
+| 聊 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u804A-erjian.png" alt="二简字形（借「聊」字位）" title="二简字形，Unicode 未收录；借用 U+804A「聊」字位，摹自底本专用字体"> |
+| 蔑篾 | 𰰬 |
+| 螟 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u879F-erjian.png" alt="二简字形（借「螟」字位）" title="二简字形，Unicode 未收录；借用 U+879F「螟」字位，摹自底本专用字体"> |
+| 蘑 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8611-erjian.png" alt="二简字形（借「蘑」字位）" title="二简字形，Unicode 未收录；借用 U+8611「蘑」字位，摹自底本专用字体"> |
+| 腻 | 胒 |
+| 蔫 | 𦮴 |
+| 蘖孽 | 𰰟 |
+| 藕 | 𰰤[^13] |
+| 遣 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9063-erjian.png" alt="二简字形（借「遣」字位）" title="二简字形，Unicode 未收录；借用 U+9063「遣」字位，摹自底本专用字体"> |
+| 谴 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8C34-erjian.png" alt="二简字形（借「谴」字位）" title="二简字形，Unicode 未收录；借用 U+8C34「谴」字位，摹自底本专用字体"> |
+| 锹 | 𫓱 |
+| 瞧 | 𥋊 |
+| 瘸 | 疦 |
+| 瓤 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u74E4-erjian.png" alt="二简字形（借「瓤」字位）" title="二简字形，Unicode 未收录；借用 U+74E4「瓤」字位，摹自底本专用字体"> |
+| 攘 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6518-erjian.png" alt="二简字形（借「攘」字位）" title="二简字形，Unicode 未收录；借用 U+6518「攘」字位，摹自底本专用字体"> |
+| 孺 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5B7A-erjian.png" alt="二简字形（借「孺」字位）" title="二简字形，Unicode 未收录；借用 U+5B7A「孺」字位，摹自底本专用字体"> |
+| 蠕 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8815-erjian.png" alt="二简字形（借「蠕」字位）" title="二简字形，Unicode 未收录；借用 U+8815「蠕」字位，摹自底本专用字体"> |
+| 辱 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8FB1-erjian.png" alt="二简字形（借「辱」字位）" title="二简字形，Unicode 未收录；借用 U+8FB1「辱」字位，摹自底本专用字体"> |
+| 褥 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8925-erjian.png" alt="二简字形（借「褥」字位）" title="二简字形，Unicode 未收录；借用 U+8925「褥」字位，摹自底本专用字体"> |
+| 撒 | 𰒼 |
+| 膻 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u81BB-erjian.png" alt="二简字形（借「膻」字位）" title="二简字形，Unicode 未收录；借用 U+81BB「膻」字位，摹自底本专用字体"> |
+| 擅 | 𢩳 |
+| 剩 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5269-erjian.png" alt="二简字形（借「剩」字位）" title="二简字形，Unicode 未收录；借用 U+5269「剩」字位，摹自底本专用字体"> |
+| 薯蔬 | 𦬸 |
+| 霜 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u971C-erjian.png" alt="二简字形（借「霜」字位）" title="二简字形，Unicode 未收录；借用 U+971C「霜」字位，摹自底本专用字体"> |
+| 肆 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8086-erjian.png" alt="二简字形（借「肆」字位）" title="二简字形，Unicode 未收录；借用 U+8086「肆」字位，摹自底本专用字体"> |
+| 穗𰬸 | 𬜨 |
+| 艇 | 𦨍 |
+| 臀 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u81C0-erjian.png" alt="二简字形（借「臀」字位）" title="二简字形，Unicode 未收录；借用 U+81C0「臀」字位，摹自底本专用字体">[^14] |
+| 瘟 | 𤵒 |
+| 膝 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u819D-erjian.png" alt="二简字形（借「膝」字位）" title="二简字形，Unicode 未收录；借用 U+819D「膝」字位，摹自底本专用字体"> |
+| 隙 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9699-erjian.png" alt="二简字形（借「隙」字位）" title="二简字形，Unicode 未收录；借用 U+9699「隙」字位，摹自底本专用字体"> |
+| 辖 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8F96-erjian.png" alt="二简字形（借「辖」字位）" title="二简字形，Unicode 未收录；借用 U+8F96「辖」字位，摹自底本专用字体"> |
+| 暇 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6687-erjian.png" alt="二简字形（借「暇」字位）" title="二简字形，Unicode 未收录；借用 U+6687「暇」字位，摹自底本专用字体"> |
+| 霞 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u96EB-erjian.png" alt="二简字形（借「雫」字位）" title="二简字形，Unicode 未收录；借用 U+96EB「雫」字位，摹自底本专用字体"> |
+| 厦 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53A6-erjian.png" alt="二简字形（借「厦」字位）" title="二简字形，Unicode 未收录；借用 U+53A6「厦」字位，摹自底本专用字体"> |
+| 掀 | 㧥 |
+| 𣔙锨 | 㭠 |
+| 嫌 | 𢙝[^15] |
+| 像 | 𰁼 |
+| 携 | 𰓊 |
+| 堰 | 𪣈 |
+| 摇 | 扷 |
+| 谣 | 𫍚 |
+| 遥 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9065-erjian.png" alt="二简字形（借「遥」字位）" title="二简字形，Unicode 未收录；借用 U+9065「遥」字位，摹自底本专用字体"> |
+| 遗 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9057-erjian.png" alt="二简字形（借「遗」字位）" title="二简字形，Unicode 未收录；借用 U+9057「遗」字位，摹自底本专用字体"> |
+| 姨 | 𫰆 |
+| 椅 | 𣎷 |
+| 屹 | 𡴭 |
+| 癔 | 𤴥 |
+| 毅 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6BC5-erjian.png" alt="二简字形（借「毅」字位）" title="二简字形，Unicode 未收录；借用 U+6BC5「毅」字位，摹自底本专用字体"> |
+| 疑 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7591-erjian.png" alt="二简字形（借「疑」字位）" title="二简字形，Unicode 未收录；借用 U+7591「疑」字位，摹自底本专用字体"> |
+| 鹰 | 𪈠 |
+| 庸 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5EB8-erjian.png" alt="二简字形（借「庸」字位）" title="二简字形，Unicode 未收录；借用 U+5EB8「庸」字位，摹自底本专用字体"> |
+| 幽 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5E7D-erjian.png" alt="二简字形（借「幽」字位）" title="二简字形，Unicode 未收录；借用 U+5E7D「幽」字位，摹自底本专用字体"> |
+| 舆 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8206-erjian.png" alt="二简字形（借「舆」字位）" title="二简字形，Unicode 未收录；借用 U+8206「舆」字位，摹自底本专用字体"> |
+| 愚 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u611A-erjian.png" alt="二简字形（借「愚」字位）" title="二简字形，Unicode 未收录；借用 U+611A「愚」字位，摹自底本专用字体"> |
+| 隅 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9685-erjian.png" alt="二简字形（借「隅」字位）" title="二简字形，Unicode 未收录；借用 U+9685「隅」字位，摹自底本专用字体"> |
+| 辕 | 𰹷 |
+| 猿 | 𤝌 |
+| 愿 | 𫹵 |
+| 越 | 迌 |
+| 熨 | 𭴈 |
+| 遭 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u906D-erjian.png" alt="二简字形（借「遭」字位）" title="二简字形，Unicode 未收录；借用 U+906D「遭」字位，摹自底本专用字体"> |
+| 糟 | 𮇘 |
+| 澡 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6FA1-erjian.png" alt="二简字形（借「澡」字位）" title="二简字形，Unicode 未收录；借用 U+6FA1「澡」字位，摹自底本专用字体"> |
+| 渣 | 泎 |
+| 铡 | 钆[^16] |
+| 绽 | 𥿕 |
+| 涨胀 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6DB1-erjian.png" alt="二简字形（借「涱」字位）" title="二简字形，Unicode 未收录；借用 U+6DB1「涱」字位，摹自底本专用字体"> |
+| 蒸 | 炡 |
+| 踵 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8E35-erjian.png" alt="二简字形（借「踵」字位）" title="二简字形，Unicode 未收录；借用 U+8E35「踵」字位，摹自底本专用字体"> |
+| 赚 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8D5A-erjian.png" alt="二简字形（借「赚」字位）" title="二简字形，Unicode 未收录；借用 U+8D5A「赚」字位，摹自底本专用字体"> |
+| 撞 | 𢬂 |
+
+### 3．特征字（32个）
+
+　　用原字的特征部分来代替原字，这样旣减少了笔画，又容易辨认。有一部分汉字的结构，描写起来很费劲，不便称说，例如，“候”字简化为“𫶬”，便于称说，易学易记。
+
+| 原字 | 简作 |
+| --- | --- |
+| 插锸臿 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u81FF-erjian.png" alt="二简字形（借「臿」字位）" title="二简字形，Unicode 未收录；借用 U+81FF「臿」字位，摹自底本专用字体"> |
+| 得 | 𬁟 |
+| 德 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5FB7-erjian.png" alt="二简字形（借「德」字位）" title="二简字形，Unicode 未收录；借用 U+5FB7「德」字位，摹自底本专用字体"> |
+| 费 | 弗[^17] |
+| 蜂峰烽锋 | 夆 |
+| 鼓臌 | 壴 |
+| 滚衮磙 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u886E-erjian.png" alt="二简字形（借「衮」字位）" title="二简字形，Unicode 未收录；借用 U+886E「衮」字位，摹自底本专用字体"> |
+| 侯候 | 𫶬 |
+| 既 | 旡 |
+| 疆缰 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u757A-erjian.png" alt="二简字形（借「畺」字位）" title="二简字形，Unicode 未收录；借用 U+757A「畺」字位，摹自底本专用字体"> |
+| 解 | 𭷔 |
+| 浸 | 𪫆 |
+| 侵 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u4FB5-erjian.png" alt="二简字形（借「侵」字位）" title="二简字形，Unicode 未收录；借用 U+4FB5「侵」字位，摹自底本专用字体"> |
+| 鞠掬 | 匊 |
+| 垒儡 | 厽 |
+| 漏 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6F0F-erjian.png" alt="二简字形（借「漏」字位）" title="二简字形，Unicode 未收录；借用 U+6F0F「漏」字位，摹自底本专用字体"> |
+| 没 | 殳[^18] |
+| 墓 | 圶 |
+| 脑瑙碯堖 | 㐫 |
+| 能 | 𫧇 |
+| 攀 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6500-erjian.png" alt="二简字形（借「攀」字位）" title="二简字形，Unicode 未收录；借用 U+6500「攀」字位，摹自底本专用字体"> |
+| 缺 | 夬 |
+| 然 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7136-erjian.png" alt="二简字形（借「然」字位）" title="二简字形，Unicode 未收录；借用 U+7136「然」字位，摹自底本专用字体"> |
+| 弱 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5F31-erjian.png" alt="二简字形（借「弱」字位）" title="二简字形，Unicode 未收录；借用 U+5F31「弱」字位，摹自底本专用字体"> |
+| 熟 | 𰀅 |
+| 数 | 𮲓 |
+| 酸痠 | 夋 |
+| 滕藤 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6ED5-erjian.png" alt="二简字形（借「滕」字位）" title="二简字形，Unicode 未收录；借用 U+6ED5「滕」字位，摹自底本专用字体"> |
+| 微 | 𡵉 |
+| 涡娲窝莴 | 呙 |
+| 象 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8C61-erjian.png" alt="二简字形（借「象」字位）" title="二简字形，Unicode 未收录；借用 U+8C61「象」字位，摹自底本专用字体"> |
+| 旋漩 | 𭻾 |
+
+### 4．轮廓字（23个）
+
+　　保留原字的轮廓，省略其中部分笔画。用这个方法简化的字与原字形体相近。例如，“叟臾舀毁”分别简作“<img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53DF-erjian.png" alt="二简字形（借「叟」字位）" title="二简字形，Unicode 未收录；借用 U+53DF「叟」字位，摹自底本专用字体">㬰<img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8200-erjian.png" alt="二简字形（借「舀」字位）" title="二简字形，Unicode 未收录；借用 U+8200「舀」字位，摹自底本专用字体"><img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6BC1-erjian.png" alt="二简字形（借「毁」字位）" title="二简字形，Unicode 未收录；借用 U+6BC1「毁」字位，摹自底本专用字体">”，“臼”改“曰”虽只减两笔，但好写多了。
+
+| 原字 | 简作 |
+| --- | --- |
+| 蠢 | 𧉾 |
+| 篡 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7BE1-erjian.png" alt="二简字形（借「篡」字位）" title="二简字形，Unicode 未收录；借用 U+7BE1「篡」字位，摹自底本专用字体"> |
+| 等 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7B49-erjian.png" alt="二简字形（借「等」字位）" title="二简字形，Unicode 未收录；借用 U+7B49「等」字位，摹自底本专用字体"> |
+| 鬼 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9B3C-erjian.png" alt="二简字形（借「鬼」字位）" title="二简字形，Unicode 未收录；借用 U+9B3C「鬼」字位，摹自底本专用字体"> |
+| 魔 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9B54-erjian.png" alt="二简字形（借「魔」字位）" title="二简字形，Unicode 未收录；借用 U+9B54「魔」字位，摹自底本专用字体"> |
+| 磨 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u78E8-erjian.png" alt="二简字形（借「磨」字位）" title="二简字形，Unicode 未收录；借用 U+78E8「磨」字位，摹自底本专用字体"> |
+| 摩 | 𭙕 |
+| 阔 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9614-erjian.png" alt="二简字形（借「阔」字位）" title="二简字形，Unicode 未收录；借用 U+9614「阔」字位，摹自底本专用字体"> |
+| 旁 | 㝑 |
+| 鼠 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9F20-erjian.png" alt="二简字形（借「鼠」字位）" title="二简字形，Unicode 未收录；借用 U+9F20「鼠」字位，摹自底本专用字体"> |
+| 叟搜嗖飕 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53DF-erjian.png" alt="二简字形（借「叟」字位）" title="二简字形，Unicode 未收录；借用 U+53DF「叟」字位，摹自底本专用字体"> |
+| 臾 | 㬰 |
+| 舀 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8200-erjian.png" alt="二简字形（借「舀」字位）" title="二简字形，Unicode 未收录；借用 U+8200「舀」字位，摹自底本专用字体"> |
+| 隋随 | 陏 |
+| 犀 | 𰠨 |
+| 喜 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u559C-erjian.png" alt="二简字形（借「喜」字位）" title="二简字形，Unicode 未收录；借用 U+559C「喜」字位，摹自底本专用字体"> |
+| 雨 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u96E8-erjian.png" alt="二简字形（借「雨」字位）" title="二简字形，Unicode 未收录；借用 U+96E8「雨」字位，摹自底本专用字体"> |
+| 舟 | 𠔾 |
+| 角 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u89D2-erjian.png" alt="二简字形（借「角」字位）" title="二简字形，Unicode 未收录；借用 U+89D2「角」字位，摹自底本专用字体"> |
+| 耳 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8033-erjian.png" alt="二简字形（借「耳」字位）" title="二简字形，Unicode 未收录；借用 U+8033「耳」字位，摹自底本专用字体"> |
+| 南 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5357-erjian.png" alt="二简字形（借「南」字位）" title="二简字形，Unicode 未收录；借用 U+5357「南」字位，摹自底本专用字体"> |
+| 商 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5546-erjian.png" alt="二简字形（借「商」字位）" title="二简字形，Unicode 未收录；借用 U+5546「商」字位，摹自底本专用字体"> |
+| 皿 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u76BF-erjian.png" alt="二简字形（借「皿」字位）" title="二简字形，Unicode 未收录；借用 U+76BF「皿」字位，摹自底本专用字体"> |
+| 血 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8840-erjian.png" alt="二简字形（借「血」字位）" title="二简字形，Unicode 未收录；借用 U+8840「血」字位，摹自底本专用字体"> |
+
+### 5．草书楷化字（16个）
+
+　　把行草书改成楷书的形式，可以减少较多笔画。
+
+| 原字 | 简作 |
+| --- | --- |
+| 弟第 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5F1F-erjian.png" alt="二简字形（借「弟」字位）" title="二简字形，Unicode 未收录；借用 U+5F1F「弟」字位，摹自底本专用字体"> |
+| 涕嚏 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u6D95-erjian.png" alt="二简字形（借「涕」字位）" title="二简字形，Unicode 未收录；借用 U+6D95「涕」字位，摹自底本专用字体"> |
+| 亥 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u4EA5-erjian.png" alt="二简字形（借「亥」字位）" title="二简字形，Unicode 未收录；借用 U+4EA5「亥」字位，摹自底本专用字体"> |
+| 柬 | 𫠣 |
+| 阑斓 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9611-erjian.png" alt="二简字形（借「阑」字位）" title="二简字形，Unicode 未收录；借用 U+9611「阑」字位，摹自底本专用字体"> |
+| 贸 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8D38-erjian.png" alt="二简字形（借「贸」字位）" title="二简字形，Unicode 未收录；借用 U+8D38「贸」字位，摹自底本专用字体"> |
+| 照 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7167-erjian.png" alt="二简字形（借「照」字位）" title="二简字形，Unicode 未收录；借用 U+7167「照」字位，摹自底本专用字体"> |
+| 票 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7968-erjian.png" alt="二简字形（借「票」字位）" title="二简字形，Unicode 未收录；借用 U+7968「票」字位，摹自底本专用字体"> |
+| 要 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8981-erjian.png" alt="二简字形（借「要」字位）" title="二简字形，Unicode 未收录；借用 U+8981「要」字位，摹自底本专用字体"> |
+| 其 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5176-erjian.png" alt="二简字形（借「其」字位）" title="二简字形，Unicode 未收录；借用 U+5176「其」字位，摹自底本专用字体"> |
+| 夏 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u590F-erjian.png" alt="二简字形（借「夏」字位）" title="二简字形，Unicode 未收录；借用 U+590F「夏」字位，摹自底本专用字体"> |
+| 身 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8EAB-erjian.png" alt="二简字形（借「身」字位）" title="二简字形，Unicode 未收录；借用 U+8EAB「身」字位，摹自底本专用字体"> |
+| 事 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u4E8B-erjian.png" alt="二简字形（借「事」字位）" title="二简字形，Unicode 未收录；借用 U+4E8B「事」字位，摹自底本专用字体"> |
+| 高 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9AD8-erjian.png" alt="二简字形（借「高」字位）" title="二简字形，Unicode 未收录；借用 U+9AD8「高」字位，摹自底本专用字体"> |
+| 薛 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u859B-erjian.png" alt="二简字形（借「薛」字位）" title="二简字形，Unicode 未收录；借用 U+859B「薛」字位，摹自底本专用字体"> |
+| 壹 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u58F9-erjian.png" alt="二简字形（借「壹」字位）" title="二简字形，Unicode 未收录；借用 U+58F9「壹」字位，摹自底本专用字体"> |
+
+### 6．会意字（6个）
+
+　　用几个常用字（或偏旁）构成一个字，表示一个意思。例如𠆣是寡的古体，“一人为寡”。
+
+| 原字 | 简作 |
+| --- | --- |
+| 矮 | 仦 |
+| 寡 | 𠆣 |
+| 集 | 亼 |
+| 家 | 𡦼 |
+| 聚 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u805A-erjian.png" alt="二简字形（借「聚」字位）" title="二简字形，Unicode 未收录；借用 U+805A「聚」字位，摹自底本专用字体"> |
+| 燃 | 𤆂 |
+
+### 7．符号字（5个）
+
+　　把原字笔画繁难的部分，用简单的笔画（或字）代替。这些笔画（或字）在这类简化字中仅仅作为符号，不起表音表意作用。
+
+| 原字 | 简作 |
+| --- | --- |
+| 割 | 刈[^19] |
+| 奥 | 𫤭 |
+| 粤 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7CA4-erjian.png" alt="二简字形（借「粤」字位）" title="二简字形，Unicode 未收录；借用 U+7CA4「粤」字位，摹自底本专用字体"> |
+| 韩 | 𨊣 |
+| 魏 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9B4F-erjian.png" alt="二简字形（借「魏」字位）" title="二简字形，Unicode 未收录；借用 U+9B4F「魏」字位，摹自底本专用字体"> |
+
+### 8．简化偏旁
+
+#### （1）可作简化偏旁用的简化字（24个）
+
+　　24个可作简化偏旁用的简化字（均见第二表前七类），及可类推简化的字一幷列表如下。
+
+| 原字 | 简作 | 可类推简化的字 |
+| --- | --- | --- |
+| 敢 | 攼 | 橄 瞰 憨 |
+| 既 | 旡 | 慨 溉 概 |
+| 鬼 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9B3C-erjian.png" alt="二简字形（借「鬼」字位）" title="二简字形，Unicode 未收录；借用 U+9B3C「鬼」字位，摹自底本专用字体"> | 魁 魅 傀 愧 瑰 槐 魂 魄 |
+| 旁 | 㝑 | 傍 谤 榜 膀 磅 镑 耪 螃 |
+| 喜 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u559C-erjian.png" alt="二简字形（借「喜」字位）" title="二简字形，Unicode 未收录；借用 U+559C「喜」字位，摹自底本专用字体"> | 嘻 嬉 禧 熹 |
+| 叟 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53DF-erjian.png" alt="二简字形（借「叟」字位）" title="二简字形，Unicode 未收录；借用 U+53DF「叟」字位，摹自底本专用字体"> | 馊 嫂 艘 瘦 |
+| 舀 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8200-erjian.png" alt="二简字形（借「舀」字位）" title="二简字形，Unicode 未收录；借用 U+8200「舀」字位，摹自底本专用字体"> | 滔 韬 |
+| 皿 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u76BF-erjian.png" alt="二简字形（借「皿」字位）" title="二简字形，Unicode 未收录；借用 U+76BF「皿」字位，摹自底本专用字体"> | 盂 孟 猛 锰 蜢 盅 盆 盐 盏 监 槛 褴 益 谥 溢 缢 盔 盛 盖 盗 盘 盟 温 蕴 磕 瞌 阖 |
+| 血 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8840-erjian.png" alt="二简字形（借「血」字位）" title="二简字形，Unicode 未收录；借用 U+8840「血」字位，摹自底本专用字体"> | 衅 恤 |
+| 商 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5546-erjian.png" alt="二简字形（借「商」字位）" title="二简字形，Unicode 未收录；借用 U+5546「商」字位，摹自底本专用字体"> | 熵 |
+| 南 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5357-erjian.png" alt="二简字形（借「南」字位）" title="二简字形，Unicode 未收录；借用 U+5357「南」字位，摹自底本专用字体"> | 献 喃 楠 蝻 |
+| 耳 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8033-erjian.png" alt="二简字形（借「耳」字位）" title="二简字形，Unicode 未收录；借用 U+8033「耳」字位，摹自底本专用字体"> | 耶 椰 取 娶 趣 最 撮 耻 耽 耿 聆 职 联 聘 聪 洱 饵 弭 聂 摄 镊 蹑 揖 缉 楫 辑 茸 耸 聋 闻 |
+| 角 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u89D2-erjian.png" alt="二简字形（借「角」字位）" title="二简字形，Unicode 未收录；借用 U+89D2「角」字位，摹自底本专用字体"> | 斛 触 桷 确 懈 蟹 |
+| 舟 | 𠔾 | 舰 航 舷 舵 舸 舶 船 艄 艘 般 搬 瘢 磐 盘 |
+| 雨 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u96E8-erjian.png" alt="二简字形（借「雨」字位）" title="二简字形，Unicode 未收录；借用 U+96E8「雨」字位，摹自底本专用字体"> | 雯 零 雾 雹 雷 擂 镭 需 懦 糯 震 霄 霉 霖 霎 霍 霓 露 酃 |
+| 弟 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5F1F-erjian.png" alt="二简字形（借「弟」字位）" title="二简字形，Unicode 未收录；借用 U+5F1F「弟」字位，摹自底本专用字体"> | 剃 梯 锑 递 |
+| 高 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9AD8-erjian.png" alt="二简字形（借「高」字位）" title="二简字形，Unicode 未收录；借用 U+9AD8「高」字位，摹自底本专用字体"> | 敲 搞 槁 犒 稿 镐 蒿 篙 |
+| 亥 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u4EA5-erjian.png" alt="二简字形（借「亥」字位）" title="二简字形，Unicode 未收录；借用 U+4EA5「亥」字位，摹自底本专用字体"> | 刻 该 咳 孩 骇 核 赅 骸 阂 |
+| 柬 | 𫠣 | 谏 楝 |
+| 票 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7968-erjian.png" alt="二简字形（借「票」字位）" title="二简字形，Unicode 未收录；借用 U+7968「票」字位，摹自底本专用字体"> | 飘 瓢 漂 膘 瞟 镖 鳔 |
+| 要 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8981-erjian.png" alt="二简字形（借「要」字位）" title="二简字形，Unicode 未收录；借用 U+8981「要」字位，摹自底本专用字体"> | 腰 |
+| 其 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5176-erjian.png" alt="二简字形（借「其」字位）" title="二简字形，Unicode 未收录；借用 U+5176「其」字位，摹自底本专用字体"> | 期 欺 斯 嘶 撕 厮 淇 祺 棋 琪 基 箕 旗 |
+| 身 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u8EAB-erjian.png" alt="二简字形（借「身」字位）" title="二简字形，Unicode 未收录；借用 U+8EAB「身」字位，摹自底本专用字体"> | 躬 躯 躲 躺 射 谢 榭 |
+| 家 | 𡦼 | 嫁 稼 |
+
+#### （2）不能单独成字的简化偏旁（16个）
+
+　　16个不能单独成字的简化偏旁（其中爿〔pán〕、豸〔zhì〕单用时保留原字；“厥”作单字用时简作“<img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u53A5-erjian.png" alt="二简字形（借「厥」字位）" title="二简字形，Unicode 未收录；借用 U+53A5「厥」字位，摹自底本专用字体">”；“阑”作单字用时简作“<img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9611-erjian.png" alt="二简字形（借「阑」字位）" title="二简字形，Unicode 未收录；借用 U+9611「阑」字位，摹自底本专用字体">”，“阑尾”简作“兰尾”），及可类推简化的字一幷列表如下。
+
+| 原字 | 简作 | 可类推简化的字 |
+| --- | --- | --- |
+| 爿 | 丬 | 寐 |
+| 豸 | 犭 | 豺 豹 貂 貉 |
+| 厥 | 夬 | 撅 橛 獗 蹶 |
+| 阑 | 兰 | 镧 |
+| 廴 | ⻌ | 廷 挺 延 涎 蜓 筵 犍 毽 |
+| 衤 | 礻 | 补 初 衬 衫 袄 袜 袒 袖 袍 被 裆 裕 裙 裱 褂 裸 褪 褛 褶 褴 |
+| <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u9FBA-erjian.png" alt="二简字形（借「龺」字位）" title="二简字形，Unicode 未收录；借用 U+9FBA「龺」字位，摹自底本专用字体"> | 车 | 朝 嘲 潮 戟 翰 |
+| 尞 | 了 | 撩 獠 缭 |
+| 尃 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5C03-erjian.png" alt="二简字形（借「尃」字位）" title="二简字形，Unicode 未收录；借用 U+5C03「尃」字位，摹自底本专用字体"> | 博 搏 膊 缚 薄 |
+| 啇 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u5547-erjian.png" alt="二简字形（借「啇」字位）" title="二简字形，Unicode 未收录；借用 U+5547「啇」字位，摹自底本专用字体"> | 摘 嘀 滴 嫡 镝 |
+| 臽 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u81FD-erjian.png" alt="二简字形（借「臽」字位）" title="二简字形，Unicode 未收录；借用 U+81FD「臽」字位，摹自底本专用字体"> | 谄 陷 掐 馅 焰 |
+| 隹 | <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u96B9-erjian.png" alt="二简字形（借「隹」字位）" title="二简字形，Unicode 未收录；借用 U+96B9「隹」字位，摹自底本专用字体"> | 准 谁 难 傩 摊 滩 瘫 堆 推 唯 帷 惟 淮 维 潍 椎 雅 稚 雏 碓 睢 锥 雌 榫 售 雀 雇 翟 霍 瞿 崔 催 摧 焦 憔 樵 礁 蕉 鹤 截 蔺 躏 雁 雍 壅 攫 暹 鹳 颧 獾 |
+| 灬 | 一 | 杰 点 热 烈 羔 糕 羹 庶 鹧 蔗 遮 焘 烹 焉 煮 焦 憔 樵 礁 蕉 黑 默 黔 黝 黯 嘿 墨 熏 醺 煎 煦 煞 熬 熙 罴 熊 燕 熹 |
+| 𥝢 | 利 | 黎 藜 |
+| <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u7676-erjian.png" alt="二简字形（借「癶」字位）" title="二简字形，Unicode 未收录；借用 U+7676「癶」字位，摹自底本专用字体"> | 癶 | 祭 |
+| 𠇍氽 | 尒 | 恭 慕 添 舔 黍 傣 黎 藜 |
+
+## 注释
+
+[^1]: 中药秦艽的艽仍读jiāo。
+[^2]: 中药桔梗的桔仍读jié。
+[^3]: 潦草、潦倒的潦简作了，用作“雨水大”义读lào时改用涝。
+[^4]: 伶仃的仃仍读dīng。
+[^5]: 迂回的迂仍读yū。
+[^6]: 咀嚼的咀仍读jǔ。
+[^7]: 雕刻的雕简作刁，老雕的雕简作𩾗。
+[^8]: 旅的旁容易写错。膂本作吕，象脊梁骨之形。
+[^9]: 渲染的渲和宣合并简作㝉，以免同演—𰛑相混。
+[^10]: 肥沃的沃仍读wò。
+[^11]: 贮藏的贮原读zhù，现在一般都读chǔ，故与同义字储一并简作㑁。
+[^12]: 蛈仿迭跌等字。
+[^13]: 𰰤仿沤欧等字，区作声旁读ou。
+[^14]: <img class="rare-char" src="https://assets.daizhige.org/images/erjianzi/rare/u81C0-erjian.png" alt="二简字形（借「臀」字位）" title="二简字形，Unicode 未收录；借用 U+81C0「臀」字位，摹自底本专用字体">仿尾屁等字，屯作声旁。
+[^15]: 嫌是贬义字故女旁改用竖心旁，简作𢙝。
+[^16]: 元素的钆仍读gá。
+[^17]: 弗许的弗仍读fú。
+[^18]: 没与设形近，“没有”“设有”易混，需要区别。古兵器的殳仍读shū。
+[^19]: 删刈、刈除等的刈仍读yì。


### PR DESCRIPTION
转换自焰华 @Honoka55 电子化网页版（源快照与专用字体存于 .sources/honoka55/erjian-cao/）。 方案共收简化字853个、简化偏旁61个；已编入 Unicode 扩展B–I区的二简字以文字呈现，未收录的110个二简字形以字形图显示，摹自底本 erjian.ttf，该字体将未收录字形借标准码位显示。

原文脚注①–⑲转为 Markdown 脚注。