### PR TITLE
fix: 纠正庄周 CBDB ID 误匹配

### DIFF
--- a/道藏/藏外/庄子.md
+++ b/道藏/藏外/庄子.md
@@ -6,7 +6,6 @@ alt_titles:
   - 南华经
   - 南华真经
 author: '[战国]庄周'
-author_cbdb_ids: [18768]
 category: /道藏/藏外
 lastmod: 2025-09-19T04:08:50Z
 github_repo_url: https://github.com/frankslin/daizhigev20/blob/data/%E9%81%93%E8%97%8F/%E8%97%8F%E5%A4%96/%E5%BA%84%E5%AD%90.md


### PR DESCRIPTION
CBDB c_personid=18768 实际对应薛收（唐，592-624），
被 frankslin YAML 错误地写在了庄周名下。

庄周（战国，约前369-前286）与薛收是不同朝代的不同人物，
18768 不应作为庄周的 author_cbdb_ids。